### PR TITLE
Update example cases for practical conversion testing

### DIFF
--- a/docs/examples/blocks.yml
+++ b/docs/examples/blocks.yml
@@ -6,8 +6,6 @@ cases:
         - type: blockBreak
     myst: |-
       +++
-    html: |-
-      <div class="block"></div>
   - title: block break node - with metadata
     mdast:
       type: root
@@ -16,8 +14,6 @@ cases:
           meta: '{"meta": "data"}'
     myst: |-
       +++ {"meta": "data"}
-    html: |-
-      <div class="block" data-block="{&#x22;meta&#x22;: &#x22;data&#x22;}"></div>
   - title: block break node - with broken metadata
     mdast:
       type: root
@@ -26,8 +22,6 @@ cases:
           meta: '{"meta: data}'
     myst: |-
       +++ {"meta: data}
-    html: |-
-      <div class="block" data-block="{&#x22;meta: data}"></div>
   - title: block break nodes - dividing flow content
     id: blockbreak
     mdast:
@@ -44,11 +38,6 @@ cases:
       +++
       # Heading!
       +++
-    html: |-
-      <div class="block">
-        <h1>Heading!</h1>
-      </div>
-      <div class="block"></div>
   - title: block node - resolved from block breaks with flow content
     mdast:
       type: root
@@ -61,10 +50,7 @@ cases:
                 - type: text
                   value: Heading!
         - type: block
-    myst: |-
-      +++
-      # Heading!
-      +++
+          children: []
     html: |-
       <div class="block">
         <h1>Heading!</h1>

--- a/docs/examples/cmark_spec_0.30.yml
+++ b/docs/examples/cmark_spec_0.30.yml
@@ -46,7 +46,7 @@ cases:
                     - type: text
                       value: bar
     myst: "  - foo\n\n\tbar\n"
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -72,7 +72,7 @@ cases:
                   lang: ''
                   value: '  bar'
     myst: "- foo\n\n\t\tbar\n"
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -90,7 +90,7 @@ cases:
               lang: ''
               value: '  foo'
     myst: ">\t\tfoo\n"
-    html: |
+    html: |-
       <blockquote>
       <pre><code>  foo
       </code></pre>
@@ -110,7 +110,7 @@ cases:
                   lang: ''
                   value: '  foo'
     myst: "-\t\tfoo\n"
-    html: |
+    html: |-
       <ul>
       <li>
       <pre><code>  foo
@@ -127,7 +127,7 @@ cases:
             foo
             bar
     myst: "    foo\n\tbar\n"
-    html: |
+    html: |-
       <pre><code>foo
       bar
       </code></pre>
@@ -163,7 +163,7 @@ cases:
                                 - type: text
                                   value: baz
     myst: " - foo\n   - bar\n\t - baz\n"
-    html: |
+    html: |-
       <ul>
       <li>foo
       <ul>
@@ -185,7 +185,7 @@ cases:
             - type: text
               value: Foo
     myst: "#\tFoo\n"
-    html: |
+    html: |-
       <h1>Foo</h1>
   - title: Tabs - example 11
     mdast:
@@ -193,7 +193,7 @@ cases:
       children:
         - type: thematicBreak
     myst: "*\t*\t*\t\n"
-    html: |
+    html: |-
       <hr />
   - title: Backslash escapes - example 12
     mdast:
@@ -205,7 +205,7 @@ cases:
               value: '!"#$%&''()*+,-./:;<=>?@[\]^_`{|}~'
     myst: |
       \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
-    html: |
+    html: |-
       <p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
   - title: Backslash escapes - example 13
     mdast:
@@ -244,7 +244,7 @@ cases:
       \# not a heading
       \[foo]: /url "not a reference"
       \&ouml; not a character entity
-    html: |
+    html: |-
       <p>*not emphasized*
       &lt;br/&gt; not a tag
       [not a link](/foo)
@@ -268,7 +268,7 @@ cases:
                   value: emphasis
     myst: |
       \\*emphasis*
-    html: |
+    html: |-
       <p>\<em>emphasis</em></p>
   - title: Backslash escapes - example 16
     mdast:
@@ -284,7 +284,7 @@ cases:
     myst: |
       foo\
       bar
-    html: |
+    html: |-
       <p>foo<br />
       bar</p>
   - title: Backslash escapes - example 17
@@ -297,7 +297,7 @@ cases:
               value: \[\`
     myst: |
       `` \[\` ``
-    html: |
+    html: |-
       <p><code>\[\`</code></p>
   - title: Backslash escapes - example 18
     mdast:
@@ -308,7 +308,7 @@ cases:
           value: \[\]
     myst: |2
           \[\]
-    html: |
+    html: |-
       <pre><code>\[\]
       </code></pre>
   - title: Backslash escapes - example 19
@@ -322,7 +322,7 @@ cases:
       ~~~
       \[\]
       ~~~
-    html: |
+    html: |-
       <pre><code>\[\]
       </code></pre>
   - title: Backslash escapes - example 20
@@ -349,7 +349,7 @@ cases:
           value: <a href="/bar\/)">
     myst: |
       <a href="/bar\/)">
-    html: |
+    html: |-
       <a href="/bar\/)">
   - title: Backslash escapes - example 22
     mdast:
@@ -365,7 +365,7 @@ cases:
                   value: foo
     myst: |
       [foo](/bar\* "ti\*tle")
-    html: |
+    html: |-
       <p><a href="/bar*" title="ti*tle">foo</a></p>
   - title: Backslash escapes - example 23
     mdast:
@@ -383,7 +383,7 @@ cases:
       [foo]
 
       [foo]: /bar\* "ti\*tle"
-    html: |
+    html: |-
       <p><a href="/bar*" title="ti*tle">foo</a></p>
   - title: Backslash escapes - example 24
     mdast:
@@ -396,7 +396,7 @@ cases:
       ``` foo\+bar
       foo
       ```
-    html: |
+    html: |-
       <pre><code class="language-foo+bar">foo
       </code></pre>
   - title: Entity and numeric character references - example 25
@@ -406,12 +406,12 @@ cases:
         - type: paragraph
           children:
             - type: text
-              value: "\_ & © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸"
+              value: "\u0020 & © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸"
     myst: |
       &nbsp; &amp; &copy; &AElig; &Dcaron;
       &frac34; &HilbertSpace; &DifferentialD;
       &ClockwiseContourIntegral; &ngE;
-    html: |
+    html: |-
       <p>  &amp; © Æ Ď
       ¾ ℋ ⅆ
       ∲ ≧̸</p>
@@ -425,7 +425,7 @@ cases:
               value: '# Ӓ Ϡ �'
     myst: |
       &#35; &#1234; &#992; &#0;
-    html: |
+    html: |-
       <p># Ӓ Ϡ �</p>
   - title: Entity and numeric character references - example 27
     mdast:
@@ -437,7 +437,7 @@ cases:
               value: '" ആ ಫ'
     myst: |
       &#X22; &#XD06; &#xcab;
-    html: |
+    html: |-
       <p>&quot; ആ ಫ</p>
   - title: Entity and numeric character references - example 28
     mdast:
@@ -456,7 +456,7 @@ cases:
       &#87654321;
       &#abcdef0;
       &ThisIsNotDefined; &hi?;
-    html: |
+    html: |-
       <p>&amp;nbsp &amp;x; &amp;#; &amp;#x;
       &amp;#87654321;
       &amp;#abcdef0;
@@ -471,7 +471,7 @@ cases:
               value: '&copy'
     myst: |
       &copy
-    html: |
+    html: |-
       <p>&amp;copy</p>
   - title: Entity and numeric character references - example 30
     mdast:
@@ -483,7 +483,7 @@ cases:
               value: '&MadeUpEntity;'
     myst: |
       &MadeUpEntity;
-    html: |
+    html: |-
       <p>&amp;MadeUpEntity;</p>
   - title: Entity and numeric character references - example 31
     mdast:
@@ -493,7 +493,7 @@ cases:
           value: <a href="&ouml;&ouml;.html">
     myst: |
       <a href="&ouml;&ouml;.html">
-    html: |
+    html: |-
       <a href="&ouml;&ouml;.html">
   - title: Entity and numeric character references - example 32
     mdast:
@@ -509,7 +509,7 @@ cases:
                   value: foo
     myst: |
       [foo](/f&ouml;&ouml; "f&ouml;&ouml;")
-    html: |
+    html: |-
       <p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
   - title: Entity and numeric character references - example 33
     mdast:
@@ -527,7 +527,7 @@ cases:
       [foo]
 
       [foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
-    html: |
+    html: |-
       <p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
   - title: Entity and numeric character references - example 34
     mdast:
@@ -540,7 +540,7 @@ cases:
       ``` f&ouml;&ouml;
       foo
       ```
-    html: |
+    html: |-
       <pre><code class="language-föö">foo
       </code></pre>
   - title: Entity and numeric character references - example 35
@@ -553,7 +553,7 @@ cases:
               value: f&ouml;&ouml;
     myst: |
       `f&ouml;&ouml;`
-    html: |
+    html: |-
       <p><code>f&amp;ouml;&amp;ouml;</code></p>
   - title: Entity and numeric character references - example 36
     mdast:
@@ -564,7 +564,7 @@ cases:
           value: f&ouml;f&ouml;
     myst: |2
           f&ouml;f&ouml;
-    html: |
+    html: |-
       <pre><code>f&amp;ouml;f&amp;ouml;
       </code></pre>
   - title: Entity and numeric character references - example 37
@@ -583,7 +583,7 @@ cases:
     myst: |
       &#42;foo&#42;
       *foo*
-    html: |
+    html: |-
       <p>*foo*
       <em>foo</em></p>
   - title: Entity and numeric character references - example 38
@@ -607,7 +607,7 @@ cases:
       &#42; foo
 
       * foo
-    html: |
+    html: |-
       <p>* foo</p>
       <ul>
       <li>foo</li>
@@ -625,7 +625,7 @@ cases:
                 bar
     myst: |
       foo&#10;&#10;bar
-    html: |
+    html: |-
       <p>foo
 
       bar</p>
@@ -650,7 +650,7 @@ cases:
               value: '[a](url "tit")'
     myst: |
       [a](url &quot;tit&quot;)
-    html: |
+    html: |-
       <p>[a](url &quot;tit&quot;)</p>
   - title: Precedence - example 42
     mdast:
@@ -673,7 +673,7 @@ cases:
     myst: |
       - `one
       - two`
-    html: |
+    html: |-
       <ul>
       <li>`one</li>
       <li>two`</li>
@@ -689,7 +689,7 @@ cases:
       ***
       ---
       ___
-    html: |
+    html: |-
       <hr />
       <hr />
       <hr />
@@ -703,7 +703,7 @@ cases:
               value: '==='
     myst: |
       ===
-    html: |
+    html: |-
       <p>===</p>
   - title: Thematic breaks - example 46
     mdast:
@@ -720,7 +720,7 @@ cases:
       --
       **
       __
-    html: |
+    html: |-
       <p>--
       **
       __</p>
@@ -735,7 +735,7 @@ cases:
        ***
         ***
          ***
-    html: |
+    html: |-
       <hr />
       <hr />
       <hr />
@@ -748,7 +748,7 @@ cases:
           value: '***'
     myst: |2
           ***
-    html: |
+    html: |-
       <pre><code>***
       </code></pre>
   - title: Thematic breaks - example 49
@@ -764,7 +764,7 @@ cases:
     myst: |
       Foo
           ***
-    html: |
+    html: |-
       <p>Foo
       ***</p>
   - title: Thematic breaks - example 50
@@ -774,7 +774,7 @@ cases:
         - type: thematicBreak
     myst: |
       _____________________________________
-    html: |
+    html: |-
       <hr />
   - title: Thematic breaks - example 51
     mdast:
@@ -783,7 +783,7 @@ cases:
         - type: thematicBreak
     myst: |2
        - - -
-    html: |
+    html: |-
       <hr />
   - title: Thematic breaks - example 52
     mdast:
@@ -792,7 +792,7 @@ cases:
         - type: thematicBreak
     myst: |2
        **  * ** * ** * **
-    html: |
+    html: |-
       <hr />
   - title: Thematic breaks - example 53
     mdast:
@@ -801,7 +801,7 @@ cases:
         - type: thematicBreak
     myst: |
       -     -      -      -
-    html: |
+    html: |-
       <hr />
   - title: Thematic breaks - example 54
     mdast:
@@ -810,7 +810,7 @@ cases:
         - type: thematicBreak
     myst: |
       - - - -
-    html: |
+    html: |-
       <hr />
   - title: Thematic breaks - example 55
     mdast:
@@ -834,7 +834,7 @@ cases:
       a------
 
       ---a---
-    html: |
+    html: |-
       <p>_ _ _ _ a</p>
       <p>a------</p>
       <p>---a---</p>
@@ -850,7 +850,7 @@ cases:
                   value: '-'
     myst: |2
        *-*
-    html: |
+    html: |-
       <p><em>-</em></p>
   - title: Thematic breaks - example 57
     mdast:
@@ -879,7 +879,7 @@ cases:
       - foo
       ***
       - bar
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       </ul>
@@ -904,7 +904,7 @@ cases:
       Foo
       ***
       bar
-    html: |
+    html: |-
       <p>Foo</p>
       <hr />
       <p>bar</p>
@@ -925,7 +925,7 @@ cases:
       Foo
       ---
       bar
-    html: |
+    html: |-
       <h2>Foo</h2>
       <p>bar</p>
   - title: Thematic breaks - example 60
@@ -955,7 +955,7 @@ cases:
       * Foo
       * * *
       * Bar
-    html: |
+    html: |-
       <ul>
       <li>Foo</li>
       </ul>
@@ -983,7 +983,7 @@ cases:
     myst: |
       - Foo
       - * * *
-    html: |
+    html: |-
       <ul>
       <li>Foo</li>
       <li>
@@ -1031,7 +1031,7 @@ cases:
       #### foo
       ##### foo
       ###### foo
-    html: |
+    html: |-
       <h1>foo</h1>
       <h2>foo</h2>
       <h3>foo</h3>
@@ -1048,7 +1048,7 @@ cases:
               value: '####### foo'
     myst: |
       ####### foo
-    html: |
+    html: |-
       <p>####### foo</p>
   - title: ATX headings - example 64
     mdast:
@@ -1066,7 +1066,7 @@ cases:
       #5 bolt
 
       #hashtag
-    html: |
+    html: |-
       <p>#5 bolt</p>
       <p>#hashtag</p>
   - title: ATX headings - example 65
@@ -1079,7 +1079,7 @@ cases:
               value: '## foo'
     myst: |
       \## foo
-    html: |
+    html: |-
       <p>## foo</p>
   - title: ATX headings - example 66
     mdast:
@@ -1098,7 +1098,7 @@ cases:
               value: ' *baz*'
     myst: |
       # foo *bar* \*baz\*
-    html: |
+    html: |-
       <h1>foo <em>bar</em> *baz*</h1>
   - title: ATX headings - example 67
     mdast:
@@ -1111,7 +1111,7 @@ cases:
               value: foo
     myst: |
       #                  foo
-    html: |
+    html: |-
       <h1>foo</h1>
   - title: ATX headings - example 68
     mdast:
@@ -1136,7 +1136,7 @@ cases:
        ### foo
         ## foo
          # foo
-    html: |
+    html: |-
       <h3>foo</h3>
       <h2>foo</h2>
       <h1>foo</h1>
@@ -1149,7 +1149,7 @@ cases:
           value: '# foo'
     myst: |2
           # foo
-    html: |
+    html: |-
       <pre><code># foo
       </code></pre>
   - title: ATX headings - example 70
@@ -1165,7 +1165,7 @@ cases:
     myst: |
       foo
           # bar
-    html: |
+    html: |-
       <p>foo
       # bar</p>
   - title: ATX headings - example 71
@@ -1185,7 +1185,7 @@ cases:
     myst: |
       ## foo ##
         ###   bar    ###
-    html: |
+    html: |-
       <h2>foo</h2>
       <h3>bar</h3>
   - title: ATX headings - example 72
@@ -1205,7 +1205,7 @@ cases:
     myst: |
       # foo ##################################
       ##### foo ##
-    html: |
+    html: |-
       <h1>foo</h1>
       <h5>foo</h5>
   - title: ATX headings - example 73
@@ -1219,7 +1219,7 @@ cases:
               value: foo
     myst: |
       ### foo ###
-    html: |
+    html: |-
       <h3>foo</h3>
   - title: ATX headings - example 74
     mdast:
@@ -1232,7 +1232,7 @@ cases:
               value: 'foo ### b'
     myst: |
       ### foo ### b
-    html: |
+    html: |-
       <h3>foo ### b</h3>
   - title: ATX headings - example 75
     mdast:
@@ -1245,7 +1245,7 @@ cases:
               value: foo#
     myst: |
       # foo#
-    html: |
+    html: |-
       <h1>foo#</h1>
   - title: ATX headings - example 76
     mdast:
@@ -1270,7 +1270,7 @@ cases:
       ### foo \###
       ## foo #\##
       # foo \#
-    html: |
+    html: |-
       <h3>foo ###</h3>
       <h2>foo ###</h2>
       <h1>foo #</h1>
@@ -1289,7 +1289,7 @@ cases:
       ****
       ## foo
       ****
-    html: |
+    html: |-
       <hr />
       <h2>foo</h2>
       <hr />
@@ -1314,7 +1314,7 @@ cases:
       Foo bar
       # baz
       Bar foo
-    html: |
+    html: |-
       <p>Foo bar</p>
       <h1>baz</h1>
       <p>Bar foo</p>
@@ -1335,7 +1335,7 @@ cases:
       ## 
       #
       ### ###
-    html: |
+    html: |-
       <h2></h2>
       <h1></h1>
       <h3></h3>
@@ -1367,7 +1367,7 @@ cases:
 
       Foo *bar*
       ---------
-    html: |
+    html: |-
       <h1>Foo <em>bar</em></h1>
       <h2>Foo <em>bar</em></h2>
   - title: Setext headings - example 81
@@ -1389,7 +1389,7 @@ cases:
       Foo *bar
       baz*
       ====
-    html: |
+    html: |-
       <h1>Foo <em>bar
       baz</em></h1>
   - title: Setext headings - example 82
@@ -1408,7 +1408,7 @@ cases:
                     bar
                     baz
     myst: "  Foo *bar\nbaz*\t\n====\n"
-    html: |
+    html: |-
       <h1>Foo <em>bar
       baz</em></h1>
   - title: Setext headings - example 83
@@ -1431,7 +1431,7 @@ cases:
 
       Foo
       =
-    html: |
+    html: |-
       <h2>Foo</h2>
       <h1>Foo</h1>
   - title: Setext headings - example 84
@@ -1462,7 +1462,7 @@ cases:
 
         Foo
         ===
-    html: |
+    html: |-
       <h2>Foo</h2>
       <h2>Foo</h2>
       <h1>Foo</h1>
@@ -1484,7 +1484,7 @@ cases:
 
           Foo
       ---
-    html: |
+    html: |-
       <pre><code>Foo
       ---
 
@@ -1503,7 +1503,7 @@ cases:
     myst: |
       Foo
          ----
-    html: |
+    html: |-
       <h2>Foo</h2>
   - title: Setext headings - example 87
     mdast:
@@ -1518,7 +1518,7 @@ cases:
     myst: |
       Foo
           ---
-    html: |
+    html: |-
       <p>Foo
       ---</p>
   - title: Setext headings - example 88
@@ -1542,7 +1542,7 @@ cases:
 
       Foo
       --- -
-    html: |
+    html: |-
       <p>Foo
       = =</p>
       <p>Foo</p>
@@ -1559,7 +1559,7 @@ cases:
     myst: |
       Foo  
       -----
-    html: |
+    html: |-
       <h2>Foo</h2>
   - title: Setext headings - example 90
     mdast:
@@ -1573,7 +1573,7 @@ cases:
     myst: |
       Foo\
       ----
-    html: |
+    html: |-
       <h2>Foo\</h2>
   - title: Setext headings - example 91
     mdast:
@@ -1605,7 +1605,7 @@ cases:
       <a title="a lot
       ---
       of dashes"/>
-    html: |
+    html: |-
       <h2>`Foo</h2>
       <p>`</p>
       <h2>&lt;a title=&quot;a lot</h2>
@@ -1624,7 +1624,7 @@ cases:
     myst: |
       > Foo
       ---
-    html: |
+    html: |-
       <blockquote>
       <p>Foo</p>
       </blockquote>
@@ -1646,7 +1646,7 @@ cases:
       > foo
       bar
       ===
-    html: |
+    html: |-
       <blockquote>
       <p>foo
       bar
@@ -1669,7 +1669,7 @@ cases:
     myst: |
       - Foo
       ---
-    html: |
+    html: |-
       <ul>
       <li>Foo</li>
       </ul>
@@ -1689,16 +1689,19 @@ cases:
       Foo
       Bar
       ---
-    html: |
+    html: |-
       <h2>Foo
       Bar</h2>
   - title: Setext headings - example 96
     mdast:
       type: root
       children:
-        - type: code
-          lang: yaml
-          value: Foo
+        - type: thematicBreak
+        - type: heading
+          depth: 2
+          children:
+            - type: text
+              value: Foo
         - type: heading
           depth: 2
           children:
@@ -1715,7 +1718,7 @@ cases:
       Bar
       ---
       Baz
-    html: |
+    html: |-
       <hr />
       <h2>Foo</h2>
       <h2>Bar</h2>
@@ -1731,19 +1734,18 @@ cases:
     myst: |
 
       ====
-    html: |
+    html: |-
       <p>====</p>
   - title: Setext headings - example 98
     mdast:
       type: root
       children:
-        - type: code
-          lang: yaml
-          value: ''
+        - type: thematicBreak
+        - type: thematicBreak
     myst: |
       ---
       ---
-    html: |
+    html: |-
       <hr />
       <hr />
   - title: Setext headings - example 99
@@ -1763,7 +1765,7 @@ cases:
     myst: |
       - foo
       -----
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       </ul>
@@ -1779,7 +1781,7 @@ cases:
     myst: |2
           foo
       ---
-    html: |
+    html: |-
       <pre><code>foo
       </code></pre>
       <hr />
@@ -1797,7 +1799,7 @@ cases:
     myst: |
       > foo
       -----
-    html: |
+    html: |-
       <blockquote>
       <p>foo</p>
       </blockquote>
@@ -1814,7 +1816,7 @@ cases:
     myst: |
       \> foo
       ------
-    html: |
+    html: |-
       <h2>&gt; foo</h2>
   - title: Setext headings - example 103
     mdast:
@@ -1839,7 +1841,7 @@ cases:
       bar
       ---
       baz
-    html: |
+    html: |-
       <p>Foo</p>
       <h2>bar</h2>
       <p>baz</p>
@@ -1865,7 +1867,7 @@ cases:
       ---
 
       baz
-    html: |
+    html: |-
       <p>Foo
       bar</p>
       <hr />
@@ -1890,7 +1892,7 @@ cases:
       bar
       * * *
       baz
-    html: |
+    html: |-
       <p>Foo
       bar</p>
       <hr />
@@ -1912,7 +1914,7 @@ cases:
       bar
       \---
       baz
-    html: |
+    html: |-
       <p>Foo
       bar
       ---
@@ -1929,7 +1931,7 @@ cases:
     myst: |2
           a simple
             indented code block
-    html: |
+    html: |-
       <pre><code>a simple
         indented code block
       </code></pre>
@@ -1956,7 +1958,7 @@ cases:
         - foo
 
           bar
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -1992,7 +1994,7 @@ cases:
       1.  foo
 
           - bar
-    html: |
+    html: |-
       <ol>
       <li>
       <p>foo</p>
@@ -2017,7 +2019,7 @@ cases:
           *hi*
 
           - one
-    html: |
+    html: |-
       <pre><code>&lt;a/&gt;
       *hi*
 
@@ -2045,7 +2047,7 @@ cases:
        
        
           chunk3
-    html: |
+    html: |-
       <pre><code>chunk1
 
       chunk2
@@ -2068,7 +2070,7 @@ cases:
           chunk1
             
             chunk2
-    html: |
+    html: |-
       <pre><code>chunk1
         
         chunk2
@@ -2087,7 +2089,7 @@ cases:
       Foo
           bar
 
-    html: |
+    html: |-
       <p>Foo
       bar</p>
   - title: Indented code blocks - example 114
@@ -2104,7 +2106,7 @@ cases:
     myst: |2
           foo
       bar
-    html: |
+    html: |-
       <pre><code>foo
       </code></pre>
       <p>bar</p>
@@ -2136,7 +2138,7 @@ cases:
       ------
           foo
       ----
-    html: |
+    html: |-
       <h1>Heading</h1>
       <pre><code>foo
       </code></pre>
@@ -2156,7 +2158,7 @@ cases:
     myst: |2
               foo
           bar
-    html: |
+    html: |-
       <pre><code>    foo
       bar
       </code></pre>
@@ -2173,7 +2175,7 @@ cases:
           foo
           
 
-    html: |
+    html: |-
       <pre><code>foo
       </code></pre>
   - title: Indented code blocks - example 118
@@ -2183,9 +2185,8 @@ cases:
         - type: code
           lang: ''
           value: 'foo  '
-    myst: |2
-          foo
-    html: |
+    myst: '    foo  '
+    html: |-
       <pre><code>foo  
       </code></pre>
   - title: Fenced code blocks - example 119
@@ -2202,7 +2203,7 @@ cases:
       <
        >
       ```
-    html: |
+    html: |-
       <pre><code>&lt;
        &gt;
       </code></pre>
@@ -2220,7 +2221,7 @@ cases:
       <
        >
       ~~~
-    html: |
+    html: |-
       <pre><code>&lt;
        &gt;
       </code></pre>
@@ -2236,7 +2237,7 @@ cases:
       ``
       foo
       ``
-    html: |
+    html: |-
       <p><code>foo</code></p>
   - title: Fenced code blocks - example 122
     mdast:
@@ -2252,7 +2253,7 @@ cases:
       aaa
       ~~~
       ```
-    html: |
+    html: |-
       <pre><code>aaa
       ~~~
       </code></pre>
@@ -2270,7 +2271,7 @@ cases:
       aaa
       ```
       ~~~
-    html: |
+    html: |-
       <pre><code>aaa
       ```
       </code></pre>
@@ -2288,7 +2289,7 @@ cases:
       aaa
       ```
       ``````
-    html: |
+    html: |-
       <pre><code>aaa
       ```
       </code></pre>
@@ -2306,7 +2307,7 @@ cases:
       aaa
       ~~~
       ~~~~
-    html: |
+    html: |-
       <pre><code>aaa
       ~~~
       </code></pre>
@@ -2319,7 +2320,7 @@ cases:
           value: ''
     myst: |
       ```
-    html: |
+    html: |-
       <pre><code></code></pre>
   - title: Fenced code blocks - example 127
     mdast:
@@ -2336,7 +2337,7 @@ cases:
 
       ```
       aaa
-    html: |
+    html: |-
       <pre><code>
       ```
       aaa
@@ -2359,7 +2360,7 @@ cases:
       > aaa
 
       bbb
-    html: |
+    html: |-
       <blockquote>
       <pre><code>aaa
       </code></pre>
@@ -2371,14 +2372,14 @@ cases:
       children:
         - type: code
           lang: ''
-          value: |2-
+          value: "\n  "
 
     myst: |
       ```
 
         
       ```
-    html: |
+    html: |-
       <pre><code>
         
       </code></pre>
@@ -2392,7 +2393,7 @@ cases:
     myst: |
       ```
       ```
-    html: |
+    html: |-
       <pre><code></code></pre>
   - title: Fenced code blocks - example 131
     mdast:
@@ -2408,7 +2409,7 @@ cases:
        aaa
       aaa
       ```
-    html: |
+    html: |-
       <pre><code>aaa
       aaa
       </code></pre>
@@ -2428,7 +2429,7 @@ cases:
         aaa
       aaa
         ```
-    html: |
+    html: |-
       <pre><code>aaa
       aaa
       aaa
@@ -2449,7 +2450,7 @@ cases:
           aaa
         aaa
          ```
-    html: |
+    html: |-
       <pre><code>aaa
        aaa
       aaa
@@ -2468,7 +2469,7 @@ cases:
           ```
           aaa
           ```
-    html: |
+    html: |-
       <pre><code>```
       aaa
       ```
@@ -2484,7 +2485,7 @@ cases:
       ```
       aaa
         ```
-    html: |
+    html: |-
       <pre><code>aaa
       </code></pre>
   - title: Fenced code blocks - example 136
@@ -2498,7 +2499,7 @@ cases:
          ```
       aaa
         ```
-    html: |
+    html: |-
       <pre><code>aaa
       </code></pre>
   - title: Fenced code blocks - example 137
@@ -2514,7 +2515,7 @@ cases:
       ```
       aaa
           ```
-    html: |
+    html: |-
       <pre><code>aaa
           ```
       </code></pre>
@@ -2533,7 +2534,7 @@ cases:
     myst: |
       ``` ```
       aaa
-    html: |
+    html: |-
       <p><code> </code>
       aaa</p>
   - title: Fenced code blocks - example 139
@@ -2549,7 +2550,7 @@ cases:
       ~~~~~~
       aaa
       ~~~ ~~
-    html: |
+    html: |-
       <pre><code>aaa
       ~~~ ~~
       </code></pre>
@@ -2574,7 +2575,7 @@ cases:
       bar
       ```
       baz
-    html: |
+    html: |-
       <p>foo</p>
       <pre><code>bar
       </code></pre>
@@ -2603,7 +2604,7 @@ cases:
       bar
       ~~~
       # baz
-    html: |
+    html: |-
       <h2>foo</h2>
       <pre><code>bar
       </code></pre>
@@ -2624,7 +2625,7 @@ cases:
         return 3
       end
       ```
-    html: |
+    html: |-
       <pre><code class="language-ruby">def foo(x)
         return 3
       end
@@ -2645,7 +2646,7 @@ cases:
         return 3
       end
       ~~~~~~~
-    html: |
+    html: |-
       <pre><code class="language-ruby">def foo(x)
         return 3
       end
@@ -2660,7 +2661,7 @@ cases:
     myst: |
       ````;
       ````
-    html: |
+    html: |-
       <pre><code class="language-;"></code></pre>
   - title: Fenced code blocks - example 145
     mdast:
@@ -2677,7 +2678,7 @@ cases:
     myst: |
       ``` aa ```
       foo
-    html: |
+    html: |-
       <p><code>aa</code>
       foo</p>
   - title: Fenced code blocks - example 146
@@ -2691,7 +2692,7 @@ cases:
       ~~~ aa ``` ~~~
       foo
       ~~~
-    html: |
+    html: |-
       <pre><code class="language-aa">foo
       </code></pre>
   - title: Fenced code blocks - example 147
@@ -2705,7 +2706,7 @@ cases:
       ```
       ``` aaa
       ```
-    html: |
+    html: |-
       <pre><code>``` aaa
       </code></pre>
   - title: HTML blocks - example 148
@@ -2738,7 +2739,7 @@ cases:
       _world_.
       </pre>
       </td></tr></table>
-    html: |
+    html: |-
       <table><tr><td>
       <pre>
       **Hello**,
@@ -2772,7 +2773,7 @@ cases:
       </table>
 
       okay.
-    html: |
+    html: |-
       <table>
         <tr>
           <td>
@@ -2794,7 +2795,7 @@ cases:
        <div>
         *hello*
                <foo><a>
-    html: |2
+    html: |2-
        <div>
         *hello*
                <foo><a>
@@ -2809,7 +2810,7 @@ cases:
     myst: |
       </div>
       *foo*
-    html: |
+    html: |-
       </div>
       *foo*
   - title: HTML blocks - example 152
@@ -2832,7 +2833,7 @@ cases:
       *Markdown*
 
       </DIV>
-    html: |
+    html: |-
       <DIV CLASS="foo">
       <p><em>Markdown</em></p>
       </DIV>
@@ -2849,7 +2850,7 @@ cases:
       <div id="foo"
         class="bar">
       </div>
-    html: |
+    html: |-
       <div id="foo"
         class="bar">
       </div>
@@ -2866,7 +2867,7 @@ cases:
       <div id="foo" class="bar
         baz">
       </div>
-    html: |
+    html: |-
       <div id="foo" class="bar
         baz">
       </div>
@@ -2889,7 +2890,7 @@ cases:
       *foo*
 
       *bar*
-    html: |
+    html: |-
       <div>
       *foo*
       <p><em>bar</em></p>
@@ -2904,7 +2905,7 @@ cases:
     myst: |
       <div id="foo"
       *hi*
-    html: |
+    html: |-
       <div id="foo"
       *hi*
   - title: HTML blocks - example 157
@@ -2918,7 +2919,7 @@ cases:
     myst: |
       <div class
       foo
-    html: |
+    html: |-
       <div class
       foo
   - title: HTML blocks - example 158
@@ -2932,7 +2933,7 @@ cases:
     myst: |
       <div *???-&&&-<---
       *foo*
-    html: |
+    html: |-
       <div *???-&&&-<---
       *foo*
   - title: HTML blocks - example 159
@@ -2943,7 +2944,7 @@ cases:
           value: <div><a href="bar">*foo*</a></div>
     myst: |
       <div><a href="bar">*foo*</a></div>
-    html: |
+    html: |-
       <div><a href="bar">*foo*</a></div>
   - title: HTML blocks - example 160
     mdast:
@@ -2958,7 +2959,7 @@ cases:
       <table><tr><td>
       foo
       </td></tr></table>
-    html: |
+    html: |-
       <table><tr><td>
       foo
       </td></tr></table>
@@ -2977,7 +2978,7 @@ cases:
       ``` c
       int x = 33;
       ```
-    html: |
+    html: |-
       <div></div>
       ``` c
       int x = 33;
@@ -2995,7 +2996,7 @@ cases:
       <a href="foo">
       *bar*
       </a>
-    html: |
+    html: |-
       <a href="foo">
       *bar*
       </a>
@@ -3012,7 +3013,7 @@ cases:
       <Warning>
       *bar*
       </Warning>
-    html: |
+    html: |-
       <Warning>
       *bar*
       </Warning>
@@ -3029,7 +3030,7 @@ cases:
       <i class="foo">
       *bar*
       </i>
-    html: |
+    html: |-
       <i class="foo">
       *bar*
       </i>
@@ -3044,7 +3045,7 @@ cases:
     myst: |
       </ins>
       *bar*
-    html: |
+    html: |-
       </ins>
       *bar*
   - title: HTML blocks - example 166
@@ -3060,7 +3061,7 @@ cases:
       <del>
       *foo*
       </del>
-    html: |
+    html: |-
       <del>
       *foo*
       </del>
@@ -3084,7 +3085,7 @@ cases:
       *foo*
 
       </del>
-    html: |
+    html: |-
       <del>
       <p><em>foo</em></p>
       </del>
@@ -3104,7 +3105,7 @@ cases:
               value: </del>
     myst: |
       <del>*foo*</del>
-    html: |
+    html: |-
       <p><del><em>foo</em></del></p>
   - title: HTML blocks - example 169
     mdast:
@@ -3130,7 +3131,7 @@ cases:
       main = print $ parseTags tags
       </code></pre>
       okay
-    html: |
+    html: |-
       <pre language="haskell"><code>
       import Text.HTML.TagSoup
 
@@ -3160,7 +3161,7 @@ cases:
       document.getElementById("demo").innerHTML = "Hello JavaScript!";
       </script>
       okay
-    html: |
+    html: |-
       <script type="text/javascript">
       // JavaScript example
 
@@ -3188,7 +3189,7 @@ cases:
       _bar_
 
       </textarea>
-    html: |
+    html: |-
       <textarea>
 
       *foo*
@@ -3220,7 +3221,7 @@ cases:
       p {color:blue;}
       </style>
       okay
-    html: |
+    html: |-
       <style
         type="text/css">
       h1 {color:red;}
@@ -3243,7 +3244,7 @@ cases:
         type="text/css">
 
       foo
-    html: |
+    html: |-
       <style
         type="text/css">
 
@@ -3267,7 +3268,7 @@ cases:
       > foo
 
       bar
-    html: |
+    html: |-
       <blockquote>
       <div>
       foo
@@ -3294,7 +3295,7 @@ cases:
     myst: |
       - <div>
       - foo
-    html: |
+    html: |-
       <ul>
       <li>
       <div>
@@ -3316,7 +3317,7 @@ cases:
     myst: |
       <style>p{color:red;}</style>
       *foo*
-    html: |
+    html: |-
       <style>p{color:red;}</style>
       <p><em>foo</em></p>
   - title: HTML blocks - example 177
@@ -3334,7 +3335,7 @@ cases:
     myst: |
       <!-- foo -->*bar*
       *baz*
-    html: |
+    html: |-
       <!-- foo -->*bar*
       <p><em>baz</em></p>
   - title: HTML blocks - example 178
@@ -3350,7 +3351,7 @@ cases:
       <script>
       foo
       </script>1. *bar*
-    html: |
+    html: |-
       <script>
       foo
       </script>1. *bar*
@@ -3374,7 +3375,7 @@ cases:
       bar
          baz -->
       okay
-    html: |
+    html: |-
       <!-- Foo
 
       bar
@@ -3402,7 +3403,7 @@ cases:
 
       ?>
       okay
-    html: |
+    html: |-
       <?php
 
         echo '>';
@@ -3417,7 +3418,7 @@ cases:
           value: <!DOCTYPE html>
     myst: |
       <!DOCTYPE html>
-    html: |
+    html: |-
       <!DOCTYPE html>
   - title: HTML blocks - example 182
     mdast:
@@ -3455,7 +3456,7 @@ cases:
       }
       ]]>
       okay
-    html: |
+    html: |-
       <![CDATA[
       function matchwo(a,b)
       {
@@ -3482,7 +3483,7 @@ cases:
         <!-- foo -->
 
           <!-- foo -->
-    html: |2
+    html: |2-
         <!-- foo -->
       <pre><code>&lt;!-- foo --&gt;
       </code></pre>
@@ -3499,7 +3500,7 @@ cases:
         <div>
 
           <div>
-    html: |2
+    html: |2-
         <div>
       <pre><code>&lt;div&gt;
       </code></pre>
@@ -3521,7 +3522,7 @@ cases:
       <div>
       bar
       </div>
-    html: |
+    html: |-
       <p>Foo</p>
       <div>
       bar
@@ -3541,7 +3542,7 @@ cases:
       bar
       </div>
       *foo*
-    html: |
+    html: |-
       <div>
       bar
       </div>
@@ -3565,7 +3566,7 @@ cases:
       Foo
       <a href="bar">
       baz
-    html: |
+    html: |-
       <p>Foo
       <a href="bar">
       baz</p>
@@ -3591,7 +3592,7 @@ cases:
       *Emphasized* text.
 
       </div>
-    html: |
+    html: |-
       <div>
       <p><em>Emphasized</em> text.</p>
       </div>
@@ -3608,7 +3609,7 @@ cases:
       <div>
       *Emphasized* text.
       </div>
-    html: |
+    html: |-
       <div>
       *Emphasized* text.
       </div>
@@ -3641,7 +3642,7 @@ cases:
       </tr>
 
       </table>
-    html: |
+    html: |-
       <table>
       <tr>
       <td>
@@ -3679,7 +3680,7 @@ cases:
         </tr>
 
       </table>
-    html: |
+    html: |-
       <table>
         <tr>
       <pre><code>&lt;td&gt;
@@ -3704,7 +3705,7 @@ cases:
       [foo]: /url "title"
 
       [foo]
-    html: |
+    html: |-
       <p><a href="/url" title="title">foo</a></p>
   - title: Link reference definitions - example 193
     mdast:
@@ -3724,7 +3725,7 @@ cases:
                  'the title'  
 
       [foo]
-    html: |
+    html: |-
       <p><a href="/url" title="the title">foo</a></p>
   - title: Link reference definitions - example 194
     mdast:
@@ -3742,7 +3743,7 @@ cases:
       [Foo*bar\]]:my_(url) 'title (with parens)'
 
       [Foo*bar\]]
-    html: |
+    html: |-
       <p><a href="my_(url)" title="title (with parens)">Foo*bar]</a></p>
   - title: Link reference definitions - example 195
     mdast:
@@ -3762,7 +3763,7 @@ cases:
       'title'
 
       [Foo bar]
-    html: |
+    html: |-
       <p><a href="my%20url" title="title">Foo bar</a></p>
   - title: Link reference definitions - example 196
     mdast:
@@ -3788,7 +3789,7 @@ cases:
       '
 
       [foo]
-    html: |
+    html: |-
       <p><a href="/url" title="
       title
       line1
@@ -3816,7 +3817,7 @@ cases:
       with blank line'
 
       [foo]
-    html: |
+    html: |-
       <p>[foo]: /url 'title</p>
       <p>with blank line'</p>
       <p>[foo]</p>
@@ -3836,7 +3837,7 @@ cases:
       /url
 
       [foo]
-    html: |
+    html: |-
       <p><a href="/url">foo</a></p>
   - title: Link reference definitions - example 199
     mdast:
@@ -3854,7 +3855,7 @@ cases:
       [foo]:
 
       [foo]
-    html: |
+    html: |-
       <p>[foo]:</p>
       <p>[foo]</p>
   - title: Link reference definitions - example 200
@@ -3872,7 +3873,7 @@ cases:
       [foo]: <>
 
       [foo]
-    html: |
+    html: |-
       <p><a href="">foo</a></p>
   - title: Link reference definitions - example 201
     mdast:
@@ -3894,7 +3895,7 @@ cases:
       [foo]: <bar>(baz)
 
       [foo]
-    html: |
+    html: |-
       <p>[foo]: <bar>(baz)</p>
       <p>[foo]</p>
   - title: Link reference definitions - example 202
@@ -3913,7 +3914,7 @@ cases:
       [foo]: /url\bar\*baz "foo\"bar\baz"
 
       [foo]
-    html: |
+    html: |-
       <p><a href="/url%5Cbar*baz" title="foo&quot;bar\baz">foo</a></p>
   - title: Link reference definitions - example 203
     mdast:
@@ -3930,7 +3931,7 @@ cases:
       [foo]
 
       [foo]: url
-    html: |
+    html: |-
       <p><a href="url">foo</a></p>
   - title: Link reference definitions - example 204
     mdast:
@@ -3948,7 +3949,7 @@ cases:
 
       [foo]: first
       [foo]: second
-    html: |
+    html: |-
       <p><a href="first">foo</a></p>
   - title: Link reference definitions - example 205
     mdast:
@@ -3965,7 +3966,7 @@ cases:
       [FOO]: /url
 
       [Foo]
-    html: |
+    html: |-
       <p><a href="/url">Foo</a></p>
   - title: Link reference definitions - example 206
     mdast:
@@ -3982,7 +3983,7 @@ cases:
       [ΑΓΩ]: /φου
 
       [αγω]
-    html: |
+    html: |-
       <p><a href="/%CF%86%CE%BF%CF%85">αγω</a></p>
   - title: Link reference definitions - example 207
     mdast:
@@ -4004,7 +4005,7 @@ cases:
       foo
       ]: /url
       bar
-    html: |
+    html: |-
       <p>bar</p>
   - title: Link reference definitions - example 209
     mdast:
@@ -4016,7 +4017,7 @@ cases:
               value: '[foo]: /url "title" ok'
     myst: |
       [foo]: /url "title" ok
-    html: |
+    html: |-
       <p>[foo]: /url &quot;title&quot; ok</p>
   - title: Link reference definitions - example 210
     mdast:
@@ -4029,7 +4030,7 @@ cases:
     myst: |
       [foo]: /url
       "title" ok
-    html: |
+    html: |-
       <p>&quot;title&quot; ok</p>
   - title: Link reference definitions - example 211
     mdast:
@@ -4046,7 +4047,7 @@ cases:
           [foo]: /url "title"
 
       [foo]
-    html: |
+    html: |-
       <pre><code>[foo]: /url &quot;title&quot;
       </code></pre>
       <p>[foo]</p>
@@ -4067,7 +4068,7 @@ cases:
       ```
 
       [foo]
-    html: |
+    html: |-
       <pre><code>[foo]: /url
       </code></pre>
       <p>[foo]</p>
@@ -4090,7 +4091,7 @@ cases:
       [bar]: /baz
 
       [bar]
-    html: |
+    html: |-
       <p>Foo
       [bar]: /baz</p>
       <p>[bar]</p>
@@ -4116,7 +4117,7 @@ cases:
       # [Foo]
       [foo]: /url
       > bar
-    html: |
+    html: |-
       <h1><a href="/url">Foo</a></h1>
       <blockquote>
       <p>bar</p>
@@ -4142,7 +4143,7 @@ cases:
       bar
       ===
       [foo]
-    html: |
+    html: |-
       <h1>bar</h1>
       <p><a href="/url">foo</a></p>
   - title: Link reference definitions - example 216
@@ -4163,7 +4164,7 @@ cases:
       [foo]: /url
       ===
       [foo]
-    html: |
+    html: |-
       <p>===
       <a href="/url">foo</a></p>
   - title: Link reference definitions - example 217
@@ -4204,7 +4205,7 @@ cases:
       [foo],
       [bar],
       [baz]
-    html: |
+    html: |-
       <p><a href="/foo-url" title="foo">foo</a>,
       <a href="/bar-url" title="bar">bar</a>,
       <a href="/baz-url">baz</a></p>
@@ -4225,7 +4226,7 @@ cases:
       [foo]
 
       > [foo]: /url
-    html: |
+    html: |-
       <p><a href="/url">foo</a></p>
       <blockquote>
       </blockquote>
@@ -4245,7 +4246,7 @@ cases:
       aaa
 
       bbb
-    html: |
+    html: |-
       <p>aaa</p>
       <p>bbb</p>
   - title: Paragraphs - example 220
@@ -4270,7 +4271,7 @@ cases:
 
       ccc
       ddd
-    html: |
+    html: |-
       <p>aaa
       bbb</p>
       <p>ccc
@@ -4292,7 +4293,7 @@ cases:
 
 
       bbb
-    html: |
+    html: |-
       <p>aaa</p>
       <p>bbb</p>
   - title: Paragraphs - example 222
@@ -4308,7 +4309,7 @@ cases:
     myst: |2
         aaa
        bbb
-    html: |
+    html: |-
       <p>aaa
       bbb</p>
   - title: Paragraphs - example 223
@@ -4326,7 +4327,7 @@ cases:
       aaa
                    bbb
                                              ccc
-    html: |
+    html: |-
       <p>aaa
       bbb
       ccc</p>
@@ -4343,7 +4344,7 @@ cases:
     myst: |2
          aaa
       bbb
-    html: |
+    html: |-
       <p>aaa
       bbb</p>
   - title: Paragraphs - example 225
@@ -4360,7 +4361,7 @@ cases:
     myst: |2
           aaa
       bbb
-    html: |
+    html: |-
       <pre><code>aaa
       </code></pre>
       <p>bbb</p>
@@ -4378,7 +4379,7 @@ cases:
     myst: |
       aaa     
       bbb
-    html: |
+    html: |-
       <p>aaa<br />
       bbb</p>
   - title: Blank lines - example 227
@@ -4402,7 +4403,7 @@ cases:
 
       # aaa
 
-    html: |
+    html: |-
       <p>aaa</p>
       <h1>aaa</h1>
   - title: Block quotes - example 228
@@ -4426,7 +4427,7 @@ cases:
       > # Foo
       > bar
       > baz
-    html: |
+    html: |-
       <blockquote>
       <h1>Foo</h1>
       <p>bar
@@ -4453,7 +4454,7 @@ cases:
       ># Foo
       >bar
       > baz
-    html: |
+    html: |-
       <blockquote>
       <h1>Foo</h1>
       <p>bar
@@ -4480,7 +4481,7 @@ cases:
          > # Foo
          > bar
        > baz
-    html: |
+    html: |-
       <blockquote>
       <h1>Foo</h1>
       <p>bar
@@ -4500,7 +4501,7 @@ cases:
           > # Foo
           > bar
           > baz
-    html: |
+    html: |-
       <pre><code>&gt; # Foo
       &gt; bar
       &gt; baz
@@ -4526,7 +4527,7 @@ cases:
       > # Foo
       > bar
       baz
-    html: |
+    html: |-
       <blockquote>
       <h1>Foo</h1>
       <p>bar
@@ -4549,7 +4550,7 @@ cases:
       > bar
       baz
       > foo
-    html: |
+    html: |-
       <blockquote>
       <p>bar
       baz
@@ -4569,7 +4570,7 @@ cases:
     myst: |
       > foo
       ---
-    html: |
+    html: |-
       <blockquote>
       <p>foo</p>
       </blockquote>
@@ -4601,7 +4602,7 @@ cases:
     myst: |
       > - foo
       - bar
-    html: |
+    html: |-
       <blockquote>
       <ul>
       <li>foo</li>
@@ -4625,7 +4626,7 @@ cases:
     myst: |
       >     foo
           bar
-    html: |
+    html: |-
       <blockquote>
       <pre><code>foo
       </code></pre>
@@ -4652,7 +4653,7 @@ cases:
       > ```
       foo
       ```
-    html: |
+    html: |-
       <blockquote>
       <pre><code></code></pre>
       </blockquote>
@@ -4673,7 +4674,7 @@ cases:
     myst: |
       > foo
           - bar
-    html: |
+    html: |-
       <blockquote>
       <p>foo
       - bar</p>
@@ -4686,7 +4687,7 @@ cases:
           children: []
     myst: |
       >
-    html: |
+    html: |-
       <blockquote>
       </blockquote>
   - title: Block quotes - example 240
@@ -4699,7 +4700,7 @@ cases:
       >
       >  
       >
-    html: |
+    html: |-
       <blockquote>
       </blockquote>
   - title: Block quotes - example 241
@@ -4716,7 +4717,7 @@ cases:
       >
       > foo
       >
-    html: |
+    html: |-
       <blockquote>
       <p>foo</p>
       </blockquote>
@@ -4740,7 +4741,7 @@ cases:
       > foo
 
       > bar
-    html: |
+    html: |-
       <blockquote>
       <p>foo</p>
       </blockquote>
@@ -4762,7 +4763,7 @@ cases:
     myst: |
       > foo
       > bar
-    html: |
+    html: |-
       <blockquote>
       <p>foo
       bar</p>
@@ -4785,7 +4786,7 @@ cases:
       > foo
       >
       > bar
-    html: |
+    html: |-
       <blockquote>
       <p>foo</p>
       <p>bar</p>
@@ -4807,7 +4808,7 @@ cases:
     myst: |
       foo
       > bar
-    html: |
+    html: |-
       <p>foo</p>
       <blockquote>
       <p>bar</p>
@@ -4833,7 +4834,7 @@ cases:
       > aaa
       ***
       > bbb
-    html: |
+    html: |-
       <blockquote>
       <p>aaa</p>
       </blockquote>
@@ -4856,7 +4857,7 @@ cases:
     myst: |
       > bar
       baz
-    html: |
+    html: |-
       <blockquote>
       <p>bar
       baz</p>
@@ -4879,7 +4880,7 @@ cases:
       > bar
 
       baz
-    html: |
+    html: |-
       <blockquote>
       <p>bar</p>
       </blockquote>
@@ -4902,7 +4903,7 @@ cases:
       > bar
       >
       baz
-    html: |
+    html: |-
       <blockquote>
       <p>bar</p>
       </blockquote>
@@ -4926,7 +4927,7 @@ cases:
     myst: |
       > > > foo
       bar
-    html: |
+    html: |-
       <blockquote>
       <blockquote>
       <blockquote>
@@ -4956,7 +4957,7 @@ cases:
       >>> foo
       > bar
       >>baz
-    html: |
+    html: |-
       <blockquote>
       <blockquote>
       <blockquote>
@@ -4985,7 +4986,7 @@ cases:
       >     code
 
       >    not code
-    html: |
+    html: |-
       <blockquote>
       <pre><code>code
       </code></pre>
@@ -5019,7 +5020,7 @@ cases:
           indented code
 
       > A block quote.
-    html: |
+    html: |-
       <p>A paragraph
       with two lines.</p>
       <pre><code>indented code
@@ -5061,7 +5062,7 @@ cases:
               indented code
 
           > A block quote.
-    html: |
+    html: |-
       <ol>
       <li>
       <p>A paragraph
@@ -5094,7 +5095,7 @@ cases:
       - one
 
        two
-    html: |
+    html: |-
       <ul>
       <li>one</li>
       </ul>
@@ -5122,7 +5123,7 @@ cases:
       - one
 
         two
-    html: |
+    html: |-
       <ul>
       <li>
       <p>one</p>
@@ -5149,7 +5150,7 @@ cases:
        -    one
 
            two
-    html: |
+    html: |-
       <ul>
       <li>one</li>
       </ul>
@@ -5178,7 +5179,7 @@ cases:
        -    one
 
             two
-    html: |
+    html: |-
       <ul>
       <li>
       <p>one</p>
@@ -5213,7 +5214,7 @@ cases:
          > > 1.  one
       >>
       >>     two
-    html: |
+    html: |-
       <blockquote>
       <blockquote>
       <ol>
@@ -5249,7 +5250,7 @@ cases:
       >>- one
       >>
         >  > two
-    html: |
+    html: |-
       <blockquote>
       <blockquote>
       <ul>
@@ -5274,7 +5275,7 @@ cases:
       -one
 
       2.two
-    html: |
+    html: |-
       <p>-one</p>
       <p>2.two</p>
   - title: List items - example 262
@@ -5301,7 +5302,7 @@ cases:
 
 
         bar
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -5347,7 +5348,7 @@ cases:
           baz
 
           > bam
-    html: |
+    html: |-
       <ol>
       <li>
       <p>foo</p>
@@ -5388,7 +5389,7 @@ cases:
 
 
             baz
-    html: |
+    html: |-
       <ul>
       <li>
       <p>Foo</p>
@@ -5415,7 +5416,7 @@ cases:
                   value: ok
     myst: |
       123456789. ok
-    html: |
+    html: |-
       <ol start="123456789">
       <li>ok</li>
       </ol>
@@ -5429,7 +5430,7 @@ cases:
               value: 1234567890. not ok
     myst: |
       1234567890. not ok
-    html: |
+    html: |-
       <p>1234567890. not ok</p>
   - title: List items - example 267
     mdast:
@@ -5447,7 +5448,7 @@ cases:
                   value: ok
     myst: |
       0. ok
-    html: |
+    html: |-
       <ol start="0">
       <li>ok</li>
       </ol>
@@ -5467,7 +5468,7 @@ cases:
                   value: ok
     myst: |
       003. ok
-    html: |
+    html: |-
       <ol start="3">
       <li>ok</li>
       </ol>
@@ -5481,7 +5482,7 @@ cases:
               value: '-1. not ok'
     myst: |
       -1. not ok
-    html: |
+    html: |-
       <p>-1. not ok</p>
   - title: List items - example 270
     mdast:
@@ -5505,7 +5506,7 @@ cases:
       - foo
 
             bar
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -5536,7 +5537,7 @@ cases:
         10.  foo
 
                  bar
-    html: |
+    html: |-
       <ol start="10">
       <li>
       <p>foo</p>
@@ -5564,7 +5565,7 @@ cases:
       paragraph
 
           more code
-    html: |
+    html: |-
       <pre><code>indented code
       </code></pre>
       <p>paragraph</p>
@@ -5598,7 +5599,7 @@ cases:
          paragraph
 
              more code
-    html: |
+    html: |-
       <ol>
       <li>
       <pre><code>indented code
@@ -5636,7 +5637,7 @@ cases:
          paragraph
 
              more code
-    html: |
+    html: |-
       <ol>
       <li>
       <pre><code> indented code
@@ -5662,7 +5663,7 @@ cases:
          foo
 
       bar
-    html: |
+    html: |-
       <p>foo</p>
       <p>bar</p>
   - title: List items - example 276
@@ -5686,7 +5687,7 @@ cases:
       -    foo
 
         bar
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       </ul>
@@ -5714,7 +5715,7 @@ cases:
       -  foo
 
          bar
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -5755,7 +5756,7 @@ cases:
         ```
       -
             baz
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       <li>
@@ -5783,7 +5784,7 @@ cases:
     myst: |
       -   
         foo
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       </ul>
@@ -5806,7 +5807,7 @@ cases:
       -
 
         foo
-    html: |
+    html: |-
       <ul>
       <li></li>
       </ul>
@@ -5836,7 +5837,7 @@ cases:
       - foo
       -
       - bar
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       <li></li>
@@ -5867,7 +5868,7 @@ cases:
       - foo
       -   
       - bar
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       <li></li>
@@ -5899,7 +5900,7 @@ cases:
       1. foo
       2.
       3. bar
-    html: |
+    html: |-
       <ol>
       <li>foo</li>
       <li></li>
@@ -5918,7 +5919,7 @@ cases:
               children: []
     myst: |
       *
-    html: |
+    html: |-
       <ul>
       <li></li>
       </ul>
@@ -5944,7 +5945,7 @@ cases:
 
       foo
       1.
-    html: |
+    html: |-
       <p>foo
       *</p>
       <p>foo
@@ -5983,7 +5984,7 @@ cases:
                indented code
 
            > A block quote.
-    html: |
+    html: |-
       <ol>
       <li>
       <p>A paragraph
@@ -6029,7 +6030,7 @@ cases:
                 indented code
 
             > A block quote.
-    html: |
+    html: |-
       <ol>
       <li>
       <p>A paragraph
@@ -6075,7 +6076,7 @@ cases:
                  indented code
 
              > A block quote.
-    html: |
+    html: |-
       <ol>
       <li>
       <p>A paragraph
@@ -6107,7 +6108,7 @@ cases:
                   indented code
 
               > A block quote.
-    html: |
+    html: |-
       <pre><code>1.  A paragraph
           with two lines.
 
@@ -6149,7 +6150,7 @@ cases:
                 indented code
 
             > A block quote.
-    html: |
+    html: |-
       <ol>
       <li>
       <p>A paragraph
@@ -6180,7 +6181,7 @@ cases:
     myst: |2
         1.  A paragraph
           with two lines.
-    html: |
+    html: |-
       <ol>
       <li>A paragraph
       with two lines.</li>
@@ -6210,7 +6211,7 @@ cases:
     myst: |
       > 1. > Blockquote
       continued here.
-    html: |
+    html: |-
       <blockquote>
       <ol>
       <li>
@@ -6246,7 +6247,7 @@ cases:
     myst: |
       > 1. > Blockquote
       > continued here.
-    html: |
+    html: |-
       <blockquote>
       <ol>
       <li>
@@ -6302,7 +6303,7 @@ cases:
         - bar
           - baz
             - boo
-    html: |
+    html: |-
       <ul>
       <li>foo
       <ul>
@@ -6351,7 +6352,7 @@ cases:
        - bar
         - baz
          - boo
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       <li>bar</li>
@@ -6384,7 +6385,7 @@ cases:
     myst: |
       10) foo
           - bar
-    html: |
+    html: |-
       <ol start="10">
       <li>foo
       <ul>
@@ -6418,7 +6419,7 @@ cases:
     myst: |
       10) foo
          - bar
-    html: |
+    html: |-
       <ol start="10">
       <li>foo</li>
       </ol>
@@ -6447,7 +6448,7 @@ cases:
                           value: foo
     myst: |
       - - foo
-    html: |
+    html: |-
       <ul>
       <li>
       <ul>
@@ -6486,7 +6487,7 @@ cases:
                                   value: foo
     myst: |
       1. - 2. foo
-    html: |
+    html: |-
       <ol>
       <li>
       <ul>
@@ -6529,7 +6530,7 @@ cases:
       - Bar
         ---
         baz
-    html: |
+    html: |-
       <ul>
       <li>
       <h1>Foo</h1>
@@ -6569,7 +6570,7 @@ cases:
       - foo
       - bar
       + baz
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       <li>bar</li>
@@ -6610,7 +6611,7 @@ cases:
       1. foo
       2. bar
       3) baz
-    html: |
+    html: |-
       <ol>
       <li>foo</li>
       <li>bar</li>
@@ -6644,7 +6645,7 @@ cases:
       Foo
       - bar
       - baz
-    html: |
+    html: |-
       <p>Foo</p>
       <ul>
       <li>bar</li>
@@ -6663,7 +6664,7 @@ cases:
     myst: |
       The number of windows in my house is
       14.  The number of doors is 6.
-    html: |
+    html: |-
       <p>The number of windows in my house is
       14.  The number of doors is 6.</p>
   - title: Lists - example 305
@@ -6687,7 +6688,7 @@ cases:
     myst: |
       The number of windows in my house is
       1.  The number of doors is 6.
-    html: |
+    html: |-
       <p>The number of windows in my house is</p>
       <ol>
       <li>The number of doors is 6.</li>
@@ -6728,7 +6729,7 @@ cases:
 
 
       - baz
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -6784,7 +6785,7 @@ cases:
 
 
             bim
-    html: |
+    html: |-
       <ul>
       <li>foo
       <ul>
@@ -6841,7 +6842,7 @@ cases:
 
       - baz
       - bim
-    html: |
+    html: |-
       <ul>
       <li>foo</li>
       <li>bar</li>
@@ -6892,7 +6893,7 @@ cases:
       <!-- -->
 
           code
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -6956,7 +6957,7 @@ cases:
         - e
        - f
       - g
-    html: |
+    html: |-
       <ul>
       <li>a</li>
       <li>b</li>
@@ -7002,7 +7003,7 @@ cases:
         2. b
 
          3. c
-    html: |
+    html: |-
       <ol>
       <li>
       <p>a</p>
@@ -7050,7 +7051,7 @@ cases:
         - c
          - d
           - e
-    html: |
+    html: |-
       <ul>
       <li>a</li>
       <li>b</li>
@@ -7090,7 +7091,7 @@ cases:
         2. b
 
           3. c
-    html: |
+    html: |-
       <ol>
       <li>
       <p>a</p>
@@ -7135,7 +7136,7 @@ cases:
       - b
 
       - c
-    html: |
+    html: |-
       <ul>
       <li>
       <p>a</p>
@@ -7177,7 +7178,7 @@ cases:
       *
 
       * c
-    html: |
+    html: |-
       <ul>
       <li>
       <p>a</p>
@@ -7226,7 +7227,7 @@ cases:
 
         c
       - d
-    html: |
+    html: |-
       <ul>
       <li>
       <p>a</p>
@@ -7274,7 +7275,7 @@ cases:
 
         [ref]: /url
       - d
-    html: |
+    html: |-
       <ul>
       <li>
       <p>a</p>
@@ -7320,7 +7321,7 @@ cases:
 
         ```
       - c
-    html: |
+    html: |-
       <ul>
       <li>a</li>
       <li>
@@ -7370,7 +7371,7 @@ cases:
 
           c
       - d
-    html: |
+    html: |-
       <ul>
       <li>a
       <ul>
@@ -7411,7 +7412,7 @@ cases:
         > b
         >
       * c
-    html: |
+    html: |-
       <ul>
       <li>a
       <blockquote>
@@ -7454,7 +7455,7 @@ cases:
         c
         ```
       - d
-    html: |
+    html: |-
       <ul>
       <li>a
       <blockquote>
@@ -7480,7 +7481,7 @@ cases:
                   value: a
     myst: |
       - a
-    html: |
+    html: |-
       <ul>
       <li>a</li>
       </ul>
@@ -7509,7 +7510,7 @@ cases:
     myst: |
       - a
         - b
-    html: |
+    html: |-
       <ul>
       <li>a
       <ul>
@@ -7542,7 +7543,7 @@ cases:
          ```
 
          bar
-    html: |
+    html: |-
       <ol>
       <li>
       <pre><code>foo
@@ -7583,7 +7584,7 @@ cases:
         * bar
 
         baz
-    html: |
+    html: |-
       <ul>
       <li>
       <p>foo</p>
@@ -7651,7 +7652,7 @@ cases:
       - d
         - e
         - f
-    html: |
+    html: |-
       <ul>
       <li>
       <p>a</p>
@@ -7680,7 +7681,7 @@ cases:
               value: lo`
     myst: |
       `hi`lo`
-    html: |
+    html: |-
       <p><code>hi</code>lo`</p>
   - title: Code spans - example 328
     mdast:
@@ -7692,7 +7693,7 @@ cases:
               value: foo
     myst: |
       `foo`
-    html: |
+    html: |-
       <p><code>foo</code></p>
   - title: Code spans - example 329
     mdast:
@@ -7704,7 +7705,7 @@ cases:
               value: foo ` bar
     myst: |
       `` foo ` bar ``
-    html: |
+    html: |-
       <p><code>foo ` bar</code></p>
   - title: Code spans - example 330
     mdast:
@@ -7716,7 +7717,7 @@ cases:
               value: '``'
     myst: |
       ` `` `
-    html: |
+    html: |-
       <p><code>``</code></p>
   - title: Code spans - example 331
     mdast:
@@ -7728,7 +7729,7 @@ cases:
               value: ' `` '
     myst: |
       `  ``  `
-    html: |
+    html: |-
       <p><code> `` </code></p>
   - title: Code spans - example 332
     mdast:
@@ -7740,7 +7741,7 @@ cases:
               value: ' a'
     myst: |
       ` a`
-    html: |
+    html: |-
       <p><code> a</code></p>
   - title: Code spans - example 333
     mdast:
@@ -7752,7 +7753,7 @@ cases:
               value: ' b '
     myst: |
       ` b `
-    html: |
+    html: |-
       <p><code> b </code></p>
   - title: Code spans - example 334
     mdast:
@@ -7770,7 +7771,7 @@ cases:
     myst: |
       ` `
       `  `
-    html: |
+    html: |-
       <p><code> </code>
       <code>  </code></p>
   - title: Code spans - example 335
@@ -7787,7 +7788,7 @@ cases:
       bar  
       baz
       ``
-    html: |
+    html: |-
       <p><code>foo bar   baz</code></p>
   - title: Code spans - example 336
     mdast:
@@ -7801,7 +7802,7 @@ cases:
       ``
       foo 
       ``
-    html: |
+    html: |-
       <p><code>foo </code></p>
   - title: Code spans - example 337
     mdast:
@@ -7814,7 +7815,7 @@ cases:
     myst: |
       `foo   bar 
       baz`
-    html: |
+    html: |-
       <p><code>foo   bar  baz</code></p>
   - title: Code spans - example 338
     mdast:
@@ -7828,7 +7829,7 @@ cases:
               value: bar`
     myst: |
       `foo\`bar`
-    html: |
+    html: |-
       <p><code>foo\</code>bar`</p>
   - title: Code spans - example 339
     mdast:
@@ -7840,7 +7841,7 @@ cases:
               value: foo`bar
     myst: |
       ``foo`bar``
-    html: |
+    html: |-
       <p><code>foo`bar</code></p>
   - title: Code spans - example 340
     mdast:
@@ -7852,7 +7853,7 @@ cases:
               value: foo `` bar
     myst: |
       ` foo `` bar `
-    html: |
+    html: |-
       <p><code>foo `` bar</code></p>
   - title: Code spans - example 341
     mdast:
@@ -7866,7 +7867,7 @@ cases:
               value: '*'
     myst: |
       *foo`*`
-    html: |
+    html: |-
       <p>*foo<code>*</code></p>
   - title: Code spans - example 342
     mdast:
@@ -7882,7 +7883,7 @@ cases:
               value: )
     myst: |
       [not a `link](/foo`)
-    html: |
+    html: |-
       <p>[not a <code>link](/foo</code>)</p>
   - title: Code spans - example 343
     mdast:
@@ -7896,7 +7897,7 @@ cases:
               value: '">`'
     myst: |
       `<a href="`">`
-    html: |
+    html: |-
       <p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>
   - title: Code spans - example 344
     mdast:
@@ -7910,7 +7911,7 @@ cases:
               value: '`'
     myst: |
       <a href="`">`
-    html: |
+    html: |-
       <p><a href="`">`</p>
   - title: Code spans - example 345
     mdast:
@@ -7924,7 +7925,7 @@ cases:
               value: baz>`
     myst: |
       `<http://foo.bar.`baz>`
-    html: |
+    html: |-
       <p><code>&lt;http://foo.bar.</code>baz&gt;`</p>
   - title: Code spans - example 346
     mdast:
@@ -7941,7 +7942,7 @@ cases:
               value: '`'
     myst: |
       <http://foo.bar.`baz>`
-    html: |
+    html: |-
       <p><a href="http://foo.bar.%60baz">http://foo.bar.`baz</a>`</p>
   - title: Code spans - example 347
     mdast:
@@ -7953,7 +7954,7 @@ cases:
               value: '```foo``'
     myst: |
       ```foo``
-    html: |
+    html: |-
       <p>```foo``</p>
   - title: Code spans - example 348
     mdast:
@@ -7965,7 +7966,7 @@ cases:
               value: '`foo'
     myst: |
       `foo
-    html: |
+    html: |-
       <p>`foo</p>
   - title: Code spans - example 349
     mdast:
@@ -7979,7 +7980,7 @@ cases:
               value: bar
     myst: |
       `foo``bar``
-    html: |
+    html: |-
       <p>`foo<code>bar</code></p>
   - title: Emphasis and strong emphasis - example 350
     mdast:
@@ -7993,7 +7994,7 @@ cases:
                   value: foo bar
     myst: |
       *foo bar*
-    html: |
+    html: |-
       <p><em>foo bar</em></p>
   - title: Emphasis and strong emphasis - example 351
     mdast:
@@ -8005,7 +8006,7 @@ cases:
               value: a * foo bar*
     myst: |
       a * foo bar*
-    html: |
+    html: |-
       <p>a * foo bar*</p>
   - title: Emphasis and strong emphasis - example 352
     mdast:
@@ -8017,7 +8018,7 @@ cases:
               value: a*"foo"*
     myst: |
       a*"foo"*
-    html: |
+    html: |-
       <p>a*&quot;foo&quot;*</p>
   - title: Emphasis and strong emphasis - example 353
     mdast:
@@ -8029,7 +8030,7 @@ cases:
               value: '* a *'
     myst: |
       * a *
-    html: |
+    html: |-
       <p>* a *</p>
   - title: Emphasis and strong emphasis - example 354
     mdast:
@@ -8045,7 +8046,7 @@ cases:
                   value: bar
     myst: |
       foo*bar*
-    html: |
+    html: |-
       <p>foo<em>bar</em></p>
   - title: Emphasis and strong emphasis - example 355
     mdast:
@@ -8063,7 +8064,7 @@ cases:
               value: '78'
     myst: |
       5*6*78
-    html: |
+    html: |-
       <p>5<em>6</em>78</p>
   - title: Emphasis and strong emphasis - example 356
     mdast:
@@ -8077,7 +8078,7 @@ cases:
                   value: foo bar
     myst: |
       _foo bar_
-    html: |
+    html: |-
       <p><em>foo bar</em></p>
   - title: Emphasis and strong emphasis - example 357
     mdast:
@@ -8089,7 +8090,7 @@ cases:
               value: _ foo bar_
     myst: |
       _ foo bar_
-    html: |
+    html: |-
       <p>_ foo bar_</p>
   - title: Emphasis and strong emphasis - example 358
     mdast:
@@ -8101,7 +8102,7 @@ cases:
               value: a_"foo"_
     myst: |
       a_"foo"_
-    html: |
+    html: |-
       <p>a_&quot;foo&quot;_</p>
   - title: Emphasis and strong emphasis - example 359
     mdast:
@@ -8113,7 +8114,7 @@ cases:
               value: foo_bar_
     myst: |
       foo_bar_
-    html: |
+    html: |-
       <p>foo_bar_</p>
   - title: Emphasis and strong emphasis - example 360
     mdast:
@@ -8125,7 +8126,7 @@ cases:
               value: '5_6_78'
     myst: |
       5_6_78
-    html: |
+    html: |-
       <p>5_6_78</p>
   - title: Emphasis and strong emphasis - example 361
     mdast:
@@ -8137,7 +8138,7 @@ cases:
               value: пристаням_стремятся_
     myst: |
       пристаням_стремятся_
-    html: |
+    html: |-
       <p>пристаням_стремятся_</p>
   - title: Emphasis and strong emphasis - example 362
     mdast:
@@ -8149,7 +8150,7 @@ cases:
               value: aa_"bb"_cc
     myst: |
       aa_"bb"_cc
-    html: |
+    html: |-
       <p>aa_&quot;bb&quot;_cc</p>
   - title: Emphasis and strong emphasis - example 363
     mdast:
@@ -8165,7 +8166,7 @@ cases:
                   value: (bar)
     myst: |
       foo-_(bar)_
-    html: |
+    html: |-
       <p>foo-<em>(bar)</em></p>
   - title: Emphasis and strong emphasis - example 364
     mdast:
@@ -8177,7 +8178,7 @@ cases:
               value: _foo*
     myst: |
       _foo*
-    html: |
+    html: |-
       <p>_foo*</p>
   - title: Emphasis and strong emphasis - example 365
     mdast:
@@ -8189,7 +8190,7 @@ cases:
               value: '*foo bar *'
     myst: |
       *foo bar *
-    html: |
+    html: |-
       <p>*foo bar *</p>
   - title: Emphasis and strong emphasis - example 366
     mdast:
@@ -8204,7 +8205,7 @@ cases:
     myst: |
       *foo bar
       *
-    html: |
+    html: |-
       <p>*foo bar
       *</p>
   - title: Emphasis and strong emphasis - example 367
@@ -8217,7 +8218,7 @@ cases:
               value: '*(*foo)'
     myst: |
       *(*foo)
-    html: |
+    html: |-
       <p>*(*foo)</p>
   - title: Emphasis and strong emphasis - example 368
     mdast:
@@ -8237,7 +8238,7 @@ cases:
                   value: )
     myst: |
       *(*foo*)*
-    html: |
+    html: |-
       <p><em>(<em>foo</em>)</em></p>
   - title: Emphasis and strong emphasis - example 369
     mdast:
@@ -8253,7 +8254,7 @@ cases:
               value: bar
     myst: |
       *foo*bar
-    html: |
+    html: |-
       <p><em>foo</em>bar</p>
   - title: Emphasis and strong emphasis - example 370
     mdast:
@@ -8265,7 +8266,7 @@ cases:
               value: _foo bar _
     myst: |
       _foo bar _
-    html: |
+    html: |-
       <p>_foo bar _</p>
   - title: Emphasis and strong emphasis - example 371
     mdast:
@@ -8277,7 +8278,7 @@ cases:
               value: _(_foo)
     myst: |
       _(_foo)
-    html: |
+    html: |-
       <p>_(_foo)</p>
   - title: Emphasis and strong emphasis - example 372
     mdast:
@@ -8297,7 +8298,7 @@ cases:
                   value: )
     myst: |
       _(_foo_)_
-    html: |
+    html: |-
       <p><em>(<em>foo</em>)</em></p>
   - title: Emphasis and strong emphasis - example 373
     mdast:
@@ -8309,7 +8310,7 @@ cases:
               value: _foo_bar
     myst: |
       _foo_bar
-    html: |
+    html: |-
       <p>_foo_bar</p>
   - title: Emphasis and strong emphasis - example 374
     mdast:
@@ -8321,7 +8322,7 @@ cases:
               value: _пристаням_стремятся
     myst: |
       _пристаням_стремятся
-    html: |
+    html: |-
       <p>_пристаням_стремятся</p>
   - title: Emphasis and strong emphasis - example 375
     mdast:
@@ -8335,7 +8336,7 @@ cases:
                   value: foo_bar_baz
     myst: |
       _foo_bar_baz_
-    html: |
+    html: |-
       <p><em>foo_bar_baz</em></p>
   - title: Emphasis and strong emphasis - example 376
     mdast:
@@ -8351,7 +8352,7 @@ cases:
               value: .
     myst: |
       _(bar)_.
-    html: |
+    html: |-
       <p><em>(bar)</em>.</p>
   - title: Emphasis and strong emphasis - example 377
     mdast:
@@ -8365,7 +8366,7 @@ cases:
                   value: foo bar
     myst: |
       **foo bar**
-    html: |
+    html: |-
       <p><strong>foo bar</strong></p>
   - title: Emphasis and strong emphasis - example 378
     mdast:
@@ -8377,7 +8378,7 @@ cases:
               value: '** foo bar**'
     myst: |
       ** foo bar**
-    html: |
+    html: |-
       <p>** foo bar**</p>
   - title: Emphasis and strong emphasis - example 379
     mdast:
@@ -8389,7 +8390,7 @@ cases:
               value: a**"foo"**
     myst: |
       a**"foo"**
-    html: |
+    html: |-
       <p>a**&quot;foo&quot;**</p>
   - title: Emphasis and strong emphasis - example 380
     mdast:
@@ -8405,7 +8406,7 @@ cases:
                   value: bar
     myst: |
       foo**bar**
-    html: |
+    html: |-
       <p>foo<strong>bar</strong></p>
   - title: Emphasis and strong emphasis - example 381
     mdast:
@@ -8419,7 +8420,7 @@ cases:
                   value: foo bar
     myst: |
       __foo bar__
-    html: |
+    html: |-
       <p><strong>foo bar</strong></p>
   - title: Emphasis and strong emphasis - example 382
     mdast:
@@ -8431,7 +8432,7 @@ cases:
               value: __ foo bar__
     myst: |
       __ foo bar__
-    html: |
+    html: |-
       <p>__ foo bar__</p>
   - title: Emphasis and strong emphasis - example 383
     mdast:
@@ -8446,7 +8447,7 @@ cases:
     myst: |
       __
       foo bar__
-    html: |
+    html: |-
       <p>__
       foo bar__</p>
   - title: Emphasis and strong emphasis - example 384
@@ -8459,7 +8460,7 @@ cases:
               value: a__"foo"__
     myst: |
       a__"foo"__
-    html: |
+    html: |-
       <p>a__&quot;foo&quot;__</p>
   - title: Emphasis and strong emphasis - example 385
     mdast:
@@ -8471,7 +8472,7 @@ cases:
               value: foo__bar__
     myst: |
       foo__bar__
-    html: |
+    html: |-
       <p>foo__bar__</p>
   - title: Emphasis and strong emphasis - example 386
     mdast:
@@ -8483,7 +8484,7 @@ cases:
               value: '5__6__78'
     myst: |
       5__6__78
-    html: |
+    html: |-
       <p>5__6__78</p>
   - title: Emphasis and strong emphasis - example 387
     mdast:
@@ -8495,7 +8496,7 @@ cases:
               value: пристаням__стремятся__
     myst: |
       пристаням__стремятся__
-    html: |
+    html: |-
       <p>пристаням__стремятся__</p>
   - title: Emphasis and strong emphasis - example 388
     mdast:
@@ -8515,7 +8516,7 @@ cases:
                   value: ', baz'
     myst: |
       __foo, __bar__, baz__
-    html: |
+    html: |-
       <p><strong>foo, <strong>bar</strong>, baz</strong></p>
   - title: Emphasis and strong emphasis - example 389
     mdast:
@@ -8531,7 +8532,7 @@ cases:
                   value: (bar)
     myst: |
       foo-__(bar)__
-    html: |
+    html: |-
       <p>foo-<strong>(bar)</strong></p>
   - title: Emphasis and strong emphasis - example 390
     mdast:
@@ -8543,7 +8544,7 @@ cases:
               value: '**foo bar **'
     myst: |
       **foo bar **
-    html: |
+    html: |-
       <p>**foo bar **</p>
   - title: Emphasis and strong emphasis - example 391
     mdast:
@@ -8555,7 +8556,7 @@ cases:
               value: '**(**foo)'
     myst: |
       **(**foo)
-    html: |
+    html: |-
       <p>**(**foo)</p>
   - title: Emphasis and strong emphasis - example 392
     mdast:
@@ -8575,7 +8576,7 @@ cases:
                   value: )
     myst: |
       *(**foo**)*
-    html: |
+    html: |-
       <p><em>(<strong>foo</strong>)</em></p>
   - title: Emphasis and strong emphasis - example 393
     mdast:
@@ -8603,7 +8604,7 @@ cases:
     myst: |
       **Gomphocarpus (*Gomphocarpus physocarpus*, syn.
       *Asclepias physocarpa*)**
-    html: |
+    html: |-
       <p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.
       <em>Asclepias physocarpa</em>)</strong></p>
   - title: Emphasis and strong emphasis - example 394
@@ -8624,7 +8625,7 @@ cases:
                   value: '" foo'
     myst: |
       **foo "*bar*" foo**
-    html: |
+    html: |-
       <p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>
   - title: Emphasis and strong emphasis - example 395
     mdast:
@@ -8640,7 +8641,7 @@ cases:
               value: bar
     myst: |
       **foo**bar
-    html: |
+    html: |-
       <p><strong>foo</strong>bar</p>
   - title: Emphasis and strong emphasis - example 396
     mdast:
@@ -8652,7 +8653,7 @@ cases:
               value: __foo bar __
     myst: |
       __foo bar __
-    html: |
+    html: |-
       <p>__foo bar __</p>
   - title: Emphasis and strong emphasis - example 397
     mdast:
@@ -8664,7 +8665,7 @@ cases:
               value: __(__foo)
     myst: |
       __(__foo)
-    html: |
+    html: |-
       <p>__(__foo)</p>
   - title: Emphasis and strong emphasis - example 398
     mdast:
@@ -8684,7 +8685,7 @@ cases:
                   value: )
     myst: |
       _(__foo__)_
-    html: |
+    html: |-
       <p><em>(<strong>foo</strong>)</em></p>
   - title: Emphasis and strong emphasis - example 399
     mdast:
@@ -8696,7 +8697,7 @@ cases:
               value: __foo__bar
     myst: |
       __foo__bar
-    html: |
+    html: |-
       <p>__foo__bar</p>
   - title: Emphasis and strong emphasis - example 400
     mdast:
@@ -8708,7 +8709,7 @@ cases:
               value: __пристаням__стремятся
     myst: |
       __пристаням__стремятся
-    html: |
+    html: |-
       <p>__пристаням__стремятся</p>
   - title: Emphasis and strong emphasis - example 401
     mdast:
@@ -8722,7 +8723,7 @@ cases:
                   value: foo__bar__baz
     myst: |
       __foo__bar__baz__
-    html: |
+    html: |-
       <p><strong>foo__bar__baz</strong></p>
   - title: Emphasis and strong emphasis - example 402
     mdast:
@@ -8738,7 +8739,7 @@ cases:
               value: .
     myst: |
       __(bar)__.
-    html: |
+    html: |-
       <p><strong>(bar)</strong>.</p>
   - title: Emphasis and strong emphasis - example 403
     mdast:
@@ -8757,7 +8758,7 @@ cases:
                       value: bar
     myst: |
       *foo [bar](/url)*
-    html: |
+    html: |-
       <p><em>foo <a href="/url">bar</a></em></p>
   - title: Emphasis and strong emphasis - example 404
     mdast:
@@ -8774,7 +8775,7 @@ cases:
     myst: |
       *foo
       bar*
-    html: |
+    html: |-
       <p><em>foo
       bar</em></p>
   - title: Emphasis and strong emphasis - example 405
@@ -8795,7 +8796,7 @@ cases:
                   value: ' baz'
     myst: |
       _foo __bar__ baz_
-    html: |
+    html: |-
       <p><em>foo <strong>bar</strong> baz</em></p>
   - title: Emphasis and strong emphasis - example 406
     mdast:
@@ -8815,7 +8816,7 @@ cases:
                   value: ' baz'
     myst: |
       _foo _bar_ baz_
-    html: |
+    html: |-
       <p><em>foo <em>bar</em> baz</em></p>
   - title: Emphasis and strong emphasis - example 407
     mdast:
@@ -8833,7 +8834,7 @@ cases:
                   value: ' bar'
     myst: |
       __foo_ bar_
-    html: |
+    html: |-
       <p><em><em>foo</em> bar</em></p>
   - title: Emphasis and strong emphasis - example 408
     mdast:
@@ -8851,7 +8852,7 @@ cases:
                       value: bar
     myst: |
       *foo *bar**
-    html: |
+    html: |-
       <p><em>foo <em>bar</em></em></p>
   - title: Emphasis and strong emphasis - example 409
     mdast:
@@ -8871,7 +8872,7 @@ cases:
                   value: ' baz'
     myst: |
       *foo **bar** baz*
-    html: |
+    html: |-
       <p><em>foo <strong>bar</strong> baz</em></p>
   - title: Emphasis and strong emphasis - example 410
     mdast:
@@ -8891,7 +8892,7 @@ cases:
                   value: baz
     myst: |
       *foo**bar**baz*
-    html: |
+    html: |-
       <p><em>foo<strong>bar</strong>baz</em></p>
   - title: Emphasis and strong emphasis - example 411
     mdast:
@@ -8905,7 +8906,7 @@ cases:
                   value: foo**bar
     myst: |
       *foo**bar*
-    html: |
+    html: |-
       <p><em>foo**bar</em></p>
   - title: Emphasis and strong emphasis - example 412
     mdast:
@@ -8923,7 +8924,7 @@ cases:
                   value: ' bar'
     myst: |
       ***foo** bar*
-    html: |
+    html: |-
       <p><em><strong>foo</strong> bar</em></p>
   - title: Emphasis and strong emphasis - example 413
     mdast:
@@ -8941,7 +8942,7 @@ cases:
                       value: bar
     myst: |
       *foo **bar***
-    html: |
+    html: |-
       <p><em>foo <strong>bar</strong></em></p>
   - title: Emphasis and strong emphasis - example 414
     mdast:
@@ -8959,7 +8960,7 @@ cases:
                       value: bar
     myst: |
       *foo**bar***
-    html: |
+    html: |-
       <p><em>foo<strong>bar</strong></em></p>
   - title: Emphasis and strong emphasis - example 415
     mdast:
@@ -8979,7 +8980,7 @@ cases:
               value: baz
     myst: |
       foo***bar***baz
-    html: |
+    html: |-
       <p>foo<em><strong>bar</strong></em>baz</p>
   - title: Emphasis and strong emphasis - example 416
     mdast:
@@ -9001,7 +9002,7 @@ cases:
               value: '***baz'
     myst: |
       foo******bar*********baz
-    html: |
+    html: |-
       <p>foo<strong><strong><strong>bar</strong></strong></strong>***baz</p>
   - title: Emphasis and strong emphasis - example 417
     mdast:
@@ -9027,7 +9028,7 @@ cases:
                   value: ' bop'
     myst: |
       *foo **bar *baz* bim** bop*
-    html: |
+    html: |-
       <p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>
   - title: Emphasis and strong emphasis - example 418
     mdast:
@@ -9048,7 +9049,7 @@ cases:
                           value: bar
     myst: |
       *foo [*bar*](/url)*
-    html: |
+    html: |-
       <p><em>foo <a href="/url"><em>bar</em></a></em></p>
   - title: Emphasis and strong emphasis - example 419
     mdast:
@@ -9060,7 +9061,7 @@ cases:
               value: '** is not an empty emphasis'
     myst: |
       ** is not an empty emphasis
-    html: |
+    html: |-
       <p>** is not an empty emphasis</p>
   - title: Emphasis and strong emphasis - example 420
     mdast:
@@ -9072,7 +9073,7 @@ cases:
               value: '**** is not an empty strong emphasis'
     myst: |
       **** is not an empty strong emphasis
-    html: |
+    html: |-
       <p>**** is not an empty strong emphasis</p>
   - title: Emphasis and strong emphasis - example 421
     mdast:
@@ -9091,7 +9092,7 @@ cases:
                       value: bar
     myst: |
       **foo [bar](/url)**
-    html: |
+    html: |-
       <p><strong>foo <a href="/url">bar</a></strong></p>
   - title: Emphasis and strong emphasis - example 422
     mdast:
@@ -9108,7 +9109,7 @@ cases:
     myst: |
       **foo
       bar**
-    html: |
+    html: |-
       <p><strong>foo
       bar</strong></p>
   - title: Emphasis and strong emphasis - example 423
@@ -9129,7 +9130,7 @@ cases:
                   value: ' baz'
     myst: |
       __foo _bar_ baz__
-    html: |
+    html: |-
       <p><strong>foo <em>bar</em> baz</strong></p>
   - title: Emphasis and strong emphasis - example 424
     mdast:
@@ -9149,7 +9150,7 @@ cases:
                   value: ' baz'
     myst: |
       __foo __bar__ baz__
-    html: |
+    html: |-
       <p><strong>foo <strong>bar</strong> baz</strong></p>
   - title: Emphasis and strong emphasis - example 425
     mdast:
@@ -9167,7 +9168,7 @@ cases:
                   value: ' bar'
     myst: |
       ____foo__ bar__
-    html: |
+    html: |-
       <p><strong><strong>foo</strong> bar</strong></p>
   - title: Emphasis and strong emphasis - example 426
     mdast:
@@ -9185,7 +9186,7 @@ cases:
                       value: bar
     myst: |
       **foo **bar****
-    html: |
+    html: |-
       <p><strong>foo <strong>bar</strong></strong></p>
   - title: Emphasis and strong emphasis - example 427
     mdast:
@@ -9205,7 +9206,7 @@ cases:
                   value: ' baz'
     myst: |
       **foo *bar* baz**
-    html: |
+    html: |-
       <p><strong>foo <em>bar</em> baz</strong></p>
   - title: Emphasis and strong emphasis - example 428
     mdast:
@@ -9225,7 +9226,7 @@ cases:
                   value: baz
     myst: |
       **foo*bar*baz**
-    html: |
+    html: |-
       <p><strong>foo<em>bar</em>baz</strong></p>
   - title: Emphasis and strong emphasis - example 429
     mdast:
@@ -9243,7 +9244,7 @@ cases:
                   value: ' bar'
     myst: |
       ***foo* bar**
-    html: |
+    html: |-
       <p><strong><em>foo</em> bar</strong></p>
   - title: Emphasis and strong emphasis - example 430
     mdast:
@@ -9261,7 +9262,7 @@ cases:
                       value: bar
     myst: |
       **foo *bar***
-    html: |
+    html: |-
       <p><strong>foo <em>bar</em></strong></p>
   - title: Emphasis and strong emphasis - example 431
     mdast:
@@ -9290,7 +9291,7 @@ cases:
     myst: |
       **foo *bar **baz**
       bim* bop**
-    html: |
+    html: |-
       <p><strong>foo <em>bar <strong>baz</strong>
       bim</em> bop</strong></p>
   - title: Emphasis and strong emphasis - example 432
@@ -9312,7 +9313,7 @@ cases:
                           value: bar
     myst: |
       **foo [*bar*](/url)**
-    html: |
+    html: |-
       <p><strong>foo <a href="/url"><em>bar</em></a></strong></p>
   - title: Emphasis and strong emphasis - example 433
     mdast:
@@ -9324,7 +9325,7 @@ cases:
               value: __ is not an empty emphasis
     myst: |
       __ is not an empty emphasis
-    html: |
+    html: |-
       <p>__ is not an empty emphasis</p>
   - title: Emphasis and strong emphasis - example 434
     mdast:
@@ -9336,7 +9337,7 @@ cases:
               value: ____ is not an empty strong emphasis
     myst: |
       ____ is not an empty strong emphasis
-    html: |
+    html: |-
       <p>____ is not an empty strong emphasis</p>
   - title: Emphasis and strong emphasis - example 435
     mdast:
@@ -9348,7 +9349,7 @@ cases:
               value: foo ***
     myst: |
       foo ***
-    html: |
+    html: |-
       <p>foo ***</p>
   - title: Emphasis and strong emphasis - example 436
     mdast:
@@ -9364,7 +9365,7 @@ cases:
                   value: '*'
     myst: |
       foo *\**
-    html: |
+    html: |-
       <p>foo <em>*</em></p>
   - title: Emphasis and strong emphasis - example 437
     mdast:
@@ -9380,7 +9381,7 @@ cases:
                   value: _
     myst: |
       foo *_*
-    html: |
+    html: |-
       <p>foo <em>_</em></p>
   - title: Emphasis and strong emphasis - example 438
     mdast:
@@ -9392,7 +9393,7 @@ cases:
               value: foo *****
     myst: |
       foo *****
-    html: |
+    html: |-
       <p>foo *****</p>
   - title: Emphasis and strong emphasis - example 439
     mdast:
@@ -9408,7 +9409,7 @@ cases:
                   value: '*'
     myst: |
       foo **\***
-    html: |
+    html: |-
       <p>foo <strong>*</strong></p>
   - title: Emphasis and strong emphasis - example 440
     mdast:
@@ -9424,7 +9425,7 @@ cases:
                   value: _
     myst: |
       foo **_**
-    html: |
+    html: |-
       <p>foo <strong>_</strong></p>
   - title: Emphasis and strong emphasis - example 441
     mdast:
@@ -9440,7 +9441,7 @@ cases:
                   value: foo
     myst: |
       **foo*
-    html: |
+    html: |-
       <p>*<em>foo</em></p>
   - title: Emphasis and strong emphasis - example 442
     mdast:
@@ -9456,7 +9457,7 @@ cases:
               value: '*'
     myst: |
       *foo**
-    html: |
+    html: |-
       <p><em>foo</em>*</p>
   - title: Emphasis and strong emphasis - example 443
     mdast:
@@ -9472,7 +9473,7 @@ cases:
                   value: foo
     myst: |
       ***foo**
-    html: |
+    html: |-
       <p>*<strong>foo</strong></p>
   - title: Emphasis and strong emphasis - example 444
     mdast:
@@ -9488,7 +9489,7 @@ cases:
                   value: foo
     myst: |
       ****foo*
-    html: |
+    html: |-
       <p>***<em>foo</em></p>
   - title: Emphasis and strong emphasis - example 445
     mdast:
@@ -9504,7 +9505,7 @@ cases:
               value: '*'
     myst: |
       **foo***
-    html: |
+    html: |-
       <p><strong>foo</strong>*</p>
   - title: Emphasis and strong emphasis - example 446
     mdast:
@@ -9520,7 +9521,7 @@ cases:
               value: '***'
     myst: |
       *foo****
-    html: |
+    html: |-
       <p><em>foo</em>***</p>
   - title: Emphasis and strong emphasis - example 447
     mdast:
@@ -9532,7 +9533,7 @@ cases:
               value: foo ___
     myst: |
       foo ___
-    html: |
+    html: |-
       <p>foo ___</p>
   - title: Emphasis and strong emphasis - example 448
     mdast:
@@ -9548,7 +9549,7 @@ cases:
                   value: _
     myst: |
       foo _\__
-    html: |
+    html: |-
       <p>foo <em>_</em></p>
   - title: Emphasis and strong emphasis - example 449
     mdast:
@@ -9564,7 +9565,7 @@ cases:
                   value: '*'
     myst: |
       foo _*_
-    html: |
+    html: |-
       <p>foo <em>*</em></p>
   - title: Emphasis and strong emphasis - example 450
     mdast:
@@ -9576,7 +9577,7 @@ cases:
               value: foo _____
     myst: |
       foo _____
-    html: |
+    html: |-
       <p>foo _____</p>
   - title: Emphasis and strong emphasis - example 451
     mdast:
@@ -9592,7 +9593,7 @@ cases:
                   value: _
     myst: |
       foo __\___
-    html: |
+    html: |-
       <p>foo <strong>_</strong></p>
   - title: Emphasis and strong emphasis - example 452
     mdast:
@@ -9608,7 +9609,7 @@ cases:
                   value: '*'
     myst: |
       foo __*__
-    html: |
+    html: |-
       <p>foo <strong>*</strong></p>
   - title: Emphasis and strong emphasis - example 453
     mdast:
@@ -9624,7 +9625,7 @@ cases:
                   value: foo
     myst: |
       __foo_
-    html: |
+    html: |-
       <p>_<em>foo</em></p>
   - title: Emphasis and strong emphasis - example 454
     mdast:
@@ -9640,7 +9641,7 @@ cases:
               value: _
     myst: |
       _foo__
-    html: |
+    html: |-
       <p><em>foo</em>_</p>
   - title: Emphasis and strong emphasis - example 455
     mdast:
@@ -9656,7 +9657,7 @@ cases:
                   value: foo
     myst: |
       ___foo__
-    html: |
+    html: |-
       <p>_<strong>foo</strong></p>
   - title: Emphasis and strong emphasis - example 456
     mdast:
@@ -9672,7 +9673,7 @@ cases:
                   value: foo
     myst: |
       ____foo_
-    html: |
+    html: |-
       <p>___<em>foo</em></p>
   - title: Emphasis and strong emphasis - example 457
     mdast:
@@ -9688,7 +9689,7 @@ cases:
               value: _
     myst: |
       __foo___
-    html: |
+    html: |-
       <p><strong>foo</strong>_</p>
   - title: Emphasis and strong emphasis - example 458
     mdast:
@@ -9704,7 +9705,7 @@ cases:
               value: ___
     myst: |
       _foo____
-    html: |
+    html: |-
       <p><em>foo</em>___</p>
   - title: Emphasis and strong emphasis - example 459
     mdast:
@@ -9718,7 +9719,7 @@ cases:
                   value: foo
     myst: |
       **foo**
-    html: |
+    html: |-
       <p><strong>foo</strong></p>
   - title: Emphasis and strong emphasis - example 460
     mdast:
@@ -9734,7 +9735,7 @@ cases:
                       value: foo
     myst: |
       *_foo_*
-    html: |
+    html: |-
       <p><em><em>foo</em></em></p>
   - title: Emphasis and strong emphasis - example 461
     mdast:
@@ -9748,7 +9749,7 @@ cases:
                   value: foo
     myst: |
       __foo__
-    html: |
+    html: |-
       <p><strong>foo</strong></p>
   - title: Emphasis and strong emphasis - example 462
     mdast:
@@ -9764,7 +9765,7 @@ cases:
                       value: foo
     myst: |
       _*foo*_
-    html: |
+    html: |-
       <p><em><em>foo</em></em></p>
   - title: Emphasis and strong emphasis - example 463
     mdast:
@@ -9780,7 +9781,7 @@ cases:
                       value: foo
     myst: |
       ****foo****
-    html: |
+    html: |-
       <p><strong><strong>foo</strong></strong></p>
   - title: Emphasis and strong emphasis - example 464
     mdast:
@@ -9796,7 +9797,7 @@ cases:
                       value: foo
     myst: |
       ____foo____
-    html: |
+    html: |-
       <p><strong><strong>foo</strong></strong></p>
   - title: Emphasis and strong emphasis - example 465
     mdast:
@@ -9814,7 +9815,7 @@ cases:
                           value: foo
     myst: |
       ******foo******
-    html: |
+    html: |-
       <p><strong><strong><strong>foo</strong></strong></strong></p>
   - title: Emphasis and strong emphasis - example 466
     mdast:
@@ -9830,7 +9831,7 @@ cases:
                       value: foo
     myst: |
       ***foo***
-    html: |
+    html: |-
       <p><em><strong>foo</strong></em></p>
   - title: Emphasis and strong emphasis - example 467
     mdast:
@@ -9848,7 +9849,7 @@ cases:
                           value: foo
     myst: |
       _____foo_____
-    html: |
+    html: |-
       <p><em><strong><strong>foo</strong></strong></em></p>
   - title: Emphasis and strong emphasis - example 468
     mdast:
@@ -9864,7 +9865,7 @@ cases:
               value: ' baz_'
     myst: |
       *foo _bar* baz_
-    html: |
+    html: |-
       <p><em>foo _bar</em> baz_</p>
   - title: Emphasis and strong emphasis - example 469
     mdast:
@@ -9884,7 +9885,7 @@ cases:
                   value: ' bam'
     myst: |
       *foo __bar *baz bim__ bam*
-    html: |
+    html: |-
       <p><em>foo <strong>bar *baz bim</strong> bam</em></p>
   - title: Emphasis and strong emphasis - example 470
     mdast:
@@ -9900,7 +9901,7 @@ cases:
                   value: bar baz
     myst: |
       **foo **bar baz**
-    html: |
+    html: |-
       <p>**foo <strong>bar baz</strong></p>
   - title: Emphasis and strong emphasis - example 471
     mdast:
@@ -9916,7 +9917,7 @@ cases:
                   value: bar baz
     myst: |
       *foo *bar baz*
-    html: |
+    html: |-
       <p>*foo <em>bar baz</em></p>
   - title: Emphasis and strong emphasis - example 472
     mdast:
@@ -9933,7 +9934,7 @@ cases:
                   value: bar*
     myst: |
       *[bar*](/url)
-    html: |
+    html: |-
       <p>*<a href="/url">bar*</a></p>
   - title: Emphasis and strong emphasis - example 473
     mdast:
@@ -9950,7 +9951,7 @@ cases:
                   value: bar_
     myst: |
       _foo [bar_](/url)
-    html: |
+    html: |-
       <p>_foo <a href="/url">bar_</a></p>
   - title: Emphasis and strong emphasis - example 474
     mdast:
@@ -9964,7 +9965,7 @@ cases:
               value: <img src="foo" title="*"/>
     myst: |
       *<img src="foo" title="*"/>
-    html: |
+    html: |-
       <p>*<img src="foo" title="*"/></p>
   - title: Emphasis and strong emphasis - example 475
     mdast:
@@ -9978,7 +9979,7 @@ cases:
               value: <a href="**">
     myst: |
       **<a href="**">
-    html: |
+    html: |-
       <p>**<a href="**"></p>
   - title: Emphasis and strong emphasis - example 476
     mdast:
@@ -9992,7 +9993,7 @@ cases:
               value: <a href="__">
     myst: |
       __<a href="__">
-    html: |
+    html: |-
       <p>__<a href="__"></p>
   - title: Emphasis and strong emphasis - example 477
     mdast:
@@ -10008,7 +10009,7 @@ cases:
                   value: '*'
     myst: |
       *a `*`*
-    html: |
+    html: |-
       <p><em>a <code>*</code></em></p>
   - title: Emphasis and strong emphasis - example 478
     mdast:
@@ -10024,7 +10025,7 @@ cases:
                   value: _
     myst: |
       _a `_`_
-    html: |
+    html: |-
       <p><em>a <code>_</code></em></p>
   - title: Emphasis and strong emphasis - example 479
     mdast:
@@ -10041,7 +10042,7 @@ cases:
                   value: http://foo.bar/?q=**
     myst: |
       **a<http://foo.bar/?q=**>
-    html: |
+    html: |-
       <p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
   - title: Emphasis and strong emphasis - example 480
     mdast:
@@ -10058,7 +10059,7 @@ cases:
                   value: http://foo.bar/?q=__
     myst: |
       __a<http://foo.bar/?q=__>
-    html: |
+    html: |-
       <p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
   - title: Links - example 481
     mdast:
@@ -10074,7 +10075,7 @@ cases:
                   value: link
     myst: |
       [link](/uri "title")
-    html: |
+    html: |-
       <p><a href="/uri" title="title">link</a></p>
   - title: Links - example 482
     mdast:
@@ -10089,7 +10090,7 @@ cases:
                   value: link
     myst: |
       [link](/uri)
-    html: |
+    html: |-
       <p><a href="/uri">link</a></p>
   - title: Links - example 483
     mdast:
@@ -10102,7 +10103,7 @@ cases:
               children: []
     myst: |
       [](./target.md)
-    html: |
+    html: |-
       <p><a href="./target.md"></a></p>
   - title: Links - example 484
     mdast:
@@ -10117,7 +10118,7 @@ cases:
                   value: link
     myst: |
       [link]()
-    html: |
+    html: |-
       <p><a href="">link</a></p>
   - title: Links - example 485
     mdast:
@@ -10132,7 +10133,7 @@ cases:
                   value: link
     myst: |
       [link](<>)
-    html: |
+    html: |-
       <p><a href="">link</a></p>
   - title: Links - example 486
     mdast:
@@ -10145,7 +10146,7 @@ cases:
               children: []
     myst: |
       []()
-    html: |
+    html: |-
       <p><a href=""></a></p>
   - title: Links - example 487
     mdast:
@@ -10157,7 +10158,7 @@ cases:
               value: '[link](/my uri)'
     myst: |
       [link](/my uri)
-    html: |
+    html: |-
       <p>[link](/my uri)</p>
   - title: Links - example 488
     mdast:
@@ -10172,7 +10173,7 @@ cases:
                   value: link
     myst: |
       [link](</my uri>)
-    html: |
+    html: |-
       <p><a href="/my%20uri">link</a></p>
   - title: Links - example 489
     mdast:
@@ -10187,7 +10188,7 @@ cases:
     myst: |
       [link](foo
       bar)
-    html: |
+    html: |-
       <p>[link](foo
       bar)</p>
   - title: Links - example 490
@@ -10207,7 +10208,7 @@ cases:
     myst: |
       [link](<foo
       bar>)
-    html: |
+    html: |-
       <p>[link](<foo
       bar>)</p>
   - title: Links - example 491
@@ -10223,7 +10224,7 @@ cases:
                   value: a
     myst: |
       [a](<b)c>)
-    html: |
+    html: |-
       <p><a href="b)c">a</a></p>
   - title: Links - example 492
     mdast:
@@ -10235,7 +10236,7 @@ cases:
               value: '[link](<foo>)'
     myst: |
       [link](<foo\>)
-    html: |
+    html: |-
       <p>[link](&lt;foo&gt;)</p>
   - title: Links - example 493
     mdast:
@@ -10256,7 +10257,7 @@ cases:
       [a](<b)c
       [a](<b)c>
       [a](<b>c)
-    html: |
+    html: |-
       <p>[a](&lt;b)c
       [a](&lt;b)c&gt;
       [a](<b>c)</p>
@@ -10273,7 +10274,7 @@ cases:
                   value: link
     myst: |
       [link](\(foo\))
-    html: |
+    html: |-
       <p><a href="(foo)">link</a></p>
   - title: Links - example 495
     mdast:
@@ -10288,7 +10289,7 @@ cases:
                   value: link
     myst: |
       [link](foo(and(bar)))
-    html: |
+    html: |-
       <p><a href="foo(and(bar))">link</a></p>
   - title: Links - example 496
     mdast:
@@ -10300,7 +10301,7 @@ cases:
               value: '[link](foo(and(bar))'
     myst: |
       [link](foo(and(bar))
-    html: |
+    html: |-
       <p>[link](foo(and(bar))</p>
   - title: Links - example 497
     mdast:
@@ -10315,7 +10316,7 @@ cases:
                   value: link
     myst: |
       [link](foo\(and\(bar\))
-    html: |
+    html: |-
       <p><a href="foo(and(bar)">link</a></p>
   - title: Links - example 498
     mdast:
@@ -10330,7 +10331,7 @@ cases:
                   value: link
     myst: |
       [link](<foo(and(bar)>)
-    html: |
+    html: |-
       <p><a href="foo(and(bar)">link</a></p>
   - title: Links - example 499
     mdast:
@@ -10345,7 +10346,7 @@ cases:
                   value: link
     myst: |
       [link](foo\)\:)
-    html: |
+    html: |-
       <p><a href="foo):">link</a></p>
   - title: Links - example 500
     mdast:
@@ -10378,7 +10379,7 @@ cases:
       [link](http://example.com#fragment)
 
       [link](http://example.com?foo=3#frag)
-    html: |
+    html: |-
       <p><a href="#fragment">link</a></p>
       <p><a href="http://example.com#fragment">link</a></p>
       <p><a href="http://example.com?foo=3#frag">link</a></p>
@@ -10395,7 +10396,7 @@ cases:
                   value: link
     myst: |
       [link](foo\bar)
-    html: |
+    html: |-
       <p><a href="foo%5Cbar">link</a></p>
   - title: Links - example 502
     mdast:
@@ -10410,7 +10411,7 @@ cases:
                   value: link
     myst: |
       [link](foo%20b&auml;)
-    html: |
+    html: |-
       <p><a href="foo%20b%C3%A4">link</a></p>
   - title: Links - example 503
     mdast:
@@ -10425,7 +10426,7 @@ cases:
                   value: link
     myst: |
       [link]("title")
-    html: |
+    html: |-
       <p><a href="%22title%22">link</a></p>
   - title: Links - example 504
     mdast:
@@ -10461,7 +10462,7 @@ cases:
       [link](/url "title")
       [link](/url 'title')
       [link](/url (title))
-    html: |
+    html: |-
       <p><a href="/url" title="title">link</a>
       <a href="/url" title="title">link</a>
       <a href="/url" title="title">link</a></p>
@@ -10479,7 +10480,7 @@ cases:
                   value: link
     myst: |
       [link](/url "title \"&quot;")
-    html: |
+    html: |-
       <p><a href="/url" title="title &quot;&quot;">link</a></p>
   - title: Links - example 506
     mdast:
@@ -10488,14 +10489,13 @@ cases:
         - type: paragraph
           children:
             - type: link
-              url: /url
-              title: title
+              url: "/url\u00A0\"title\""
               children:
                 - type: text
                   value: link
     myst: |
       [link](/url "title")
-    html: |
+    html: |-
       <p><a href="/url%C2%A0%22title%22">link</a></p>
   - title: Links - example 507
     mdast:
@@ -10507,7 +10507,7 @@ cases:
               value: '[link](/url "title "and" title")'
     myst: |
       [link](/url "title "and" title")
-    html: |
+    html: |-
       <p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>
   - title: Links - example 508
     mdast:
@@ -10523,7 +10523,7 @@ cases:
                   value: link
     myst: |
       [link](/url 'title "and" title')
-    html: |
+    html: |-
       <p><a href="/url" title="title &quot;and&quot; title">link</a></p>
   - title: Links - example 509
     mdast:
@@ -10540,7 +10540,7 @@ cases:
     myst: |
       [link](   /uri
         "title"  )
-    html: |
+    html: |-
       <p><a href="/uri" title="title">link</a></p>
   - title: Links - example 510
     mdast:
@@ -10552,7 +10552,7 @@ cases:
               value: '[link] (/uri)'
     myst: |
       [link] (/uri)
-    html: |
+    html: |-
       <p>[link] (/uri)</p>
   - title: Links - example 511
     mdast:
@@ -10567,7 +10567,7 @@ cases:
                   value: link [foo [bar]]
     myst: |
       [link [foo [bar]]](/uri)
-    html: |
+    html: |-
       <p><a href="/uri">link [foo [bar]]</a></p>
   - title: Links - example 512
     mdast:
@@ -10579,7 +10579,7 @@ cases:
               value: '[link] bar](/uri)'
     myst: |
       [link] bar](/uri)
-    html: |
+    html: |-
       <p>[link] bar](/uri)</p>
   - title: Links - example 513
     mdast:
@@ -10596,7 +10596,7 @@ cases:
                   value: bar
     myst: |
       [link [bar](/uri)
-    html: |
+    html: |-
       <p>[link <a href="/uri">bar</a></p>
   - title: Links - example 514
     mdast:
@@ -10611,7 +10611,7 @@ cases:
                   value: link [bar
     myst: |
       [link \[bar](/uri)
-    html: |
+    html: |-
       <p><a href="/uri">link [bar</a></p>
   - title: Links - example 515
     mdast:
@@ -10655,7 +10655,7 @@ cases:
                   alt: moon
     myst: |
       [![moon](moon.jpg)](/uri)
-    html: |
+    html: |-
       <p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
   - title: Links - example 517
     mdast:
@@ -10674,7 +10674,7 @@ cases:
               value: '](/uri)'
     myst: |
       [foo [bar](/uri)](/uri)
-    html: |
+    html: |-
       <p>[foo <a href="/uri">bar</a>](/uri)</p>
   - title: Links - example 518
     mdast:
@@ -10699,18 +10699,20 @@ cases:
               value: '](/uri)'
     myst: |
       [foo *[bar [baz](/uri)](/uri)*](/uri)
-    html: |
+    html: |-
       <p>[foo <em>[bar <a href="/uri">baz</a>](/uri)</em>](/uri)</p>
   - title: Links - example 519
     mdast:
       type: root
       children:
-        - type: image
-          url: uri3
-          alt: '[foo](uri2)'
+        - type: paragraph
+          children:
+            - type: image
+              url: uri3
+              alt: '[foo](uri2)'
     myst: |
       ![[[foo](uri1)](uri2)](uri3)
-    html: |
+    html: |-
       <p><img src="uri3" alt="[foo](uri2)" /></p>
   - title: Links - example 520
     mdast:
@@ -10727,7 +10729,7 @@ cases:
                   value: foo*
     myst: |
       *[foo*](/uri)
-    html: |
+    html: |-
       <p>*<a href="/uri">foo*</a></p>
   - title: Links - example 521
     mdast:
@@ -10742,7 +10744,7 @@ cases:
                   value: foo *bar
     myst: |
       [foo *bar](baz*)
-    html: |
+    html: |-
       <p><a href="baz*">foo *bar</a></p>
   - title: Links - example 522
     mdast:
@@ -10758,7 +10760,7 @@ cases:
               value: ' baz]'
     myst: |
       *foo [bar* baz]
-    html: |
+    html: |-
       <p><em>foo [bar</em> baz]</p>
   - title: Links - example 523
     mdast:
@@ -10772,7 +10774,7 @@ cases:
               value: <bar attr="](baz)">
     myst: |
       [foo <bar attr="](baz)">
-    html: |
+    html: |-
       <p>[foo <bar attr="](baz)"></p>
   - title: Links - example 524
     mdast:
@@ -10786,7 +10788,7 @@ cases:
               value: '](/uri)'
     myst: |
       [foo`](/uri)`
-    html: |
+    html: |-
       <p>[foo<code>](/uri)</code></p>
   - title: Links - example 525
     mdast:
@@ -10822,7 +10824,7 @@ cases:
       [foo][bar]
 
       [bar]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title">foo</a></p>
   - title: Links - example 527
     mdast:
@@ -10839,7 +10841,7 @@ cases:
       [link [foo [bar]]][ref]
 
       [ref]: /uri
-    html: |
+    html: |-
       <p><a href="/uri">link [foo [bar]]</a></p>
   - title: Links - example 528
     mdast:
@@ -10856,7 +10858,7 @@ cases:
       [link \[bar][ref]
 
       [ref]: /uri
-    html: |
+    html: |-
       <p><a href="/uri">link [bar</a></p>
   - title: Links - example 529
     mdast:
@@ -10904,7 +10906,7 @@ cases:
       [![moon](moon.jpg)][ref]
 
       [ref]: /uri
-    html: |
+    html: |-
       <p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
   - title: Links - example 531
     mdast:
@@ -10930,7 +10932,7 @@ cases:
       [foo [bar](/uri)][ref]
 
       [ref]: /uri
-    html: |
+    html: |-
       <p>[foo <a href="/uri">bar</a>]<a href="/uri">ref</a></p>
   - title: Links - example 532
     mdast:
@@ -10960,7 +10962,7 @@ cases:
       [foo *bar [baz][ref]*][ref]
 
       [ref]: /uri
-    html: |
+    html: |-
       <p>[foo <em>bar <a href="/uri">baz</a></em>]<a href="/uri">ref</a></p>
   - title: Links - example 533
     mdast:
@@ -10979,7 +10981,7 @@ cases:
       *[foo*][ref]
 
       [ref]: /uri
-    html: |
+    html: |-
       <p>*<a href="/uri">foo*</a></p>
   - title: Links - example 534
     mdast:
@@ -10998,7 +11000,7 @@ cases:
       [foo *bar][ref]*
 
       [ref]: /uri
-    html: |
+    html: |-
       <p><a href="/uri">foo *bar</a>*</p>
   - title: Links - example 535
     mdast:
@@ -11014,7 +11016,7 @@ cases:
       [foo <bar attr="][ref]">
 
       [ref]: /uri
-    html: |
+    html: |-
       <p>[foo <bar attr="][ref]"></p>
   - title: Links - example 536
     mdast:
@@ -11030,7 +11032,7 @@ cases:
       [foo`][ref]`
 
       [ref]: /uri
-    html: |
+    html: |-
       <p>[foo<code>][ref]</code></p>
   - title: Links - example 537
     mdast:
@@ -11068,7 +11070,7 @@ cases:
       [foo][BaR]
 
       [bar]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title">foo</a></p>
   - title: Links - example 539
     mdast:
@@ -11085,7 +11087,7 @@ cases:
       [ẞ]
 
       [SS]: /url
-    html: |
+    html: |-
       <p><a href="/url">ẞ</a></p>
   - title: Links - example 540
     mdast:
@@ -11103,7 +11105,7 @@ cases:
         bar]: /url
 
       [Baz][Foo bar]
-    html: |
+    html: |-
       <p><a href="/url">Baz</a></p>
   - title: Links - example 541
     mdast:
@@ -11123,7 +11125,7 @@ cases:
       [foo] [bar]
 
       [bar]: /url "title"
-    html: |
+    html: |-
       <p>[foo] <a href="/url" title="title">bar</a></p>
   - title: Links - example 542
     mdast:
@@ -11145,7 +11147,7 @@ cases:
       [bar]
 
       [bar]: /url "title"
-    html: |
+    html: |-
       <p>[foo]
       <a href="/url" title="title">bar</a></p>
   - title: Links - example 543
@@ -11165,7 +11167,7 @@ cases:
       [foo]: /url2
 
       [bar][foo]
-    html: |
+    html: |-
       <p><a href="/url1">bar</a></p>
   - title: Links - example 544
     mdast:
@@ -11179,7 +11181,7 @@ cases:
       [bar][foo\!]
 
       [foo!]: /url
-    html: |
+    html: |-
       <p>[bar][foo!]</p>
   - title: Links - example 545
     mdast:
@@ -11197,7 +11199,7 @@ cases:
       [foo][ref[]
 
       [ref[]: /uri
-    html: |
+    html: |-
       <p>[foo][ref[]</p>
       <p>[ref[]: /uri</p>
   - title: Links - example 546
@@ -11216,7 +11218,7 @@ cases:
       [foo][ref[bar]]
 
       [ref[bar]]: /uri
-    html: |
+    html: |-
       <p>[foo][ref[bar]]</p>
       <p>[ref[bar]]: /uri</p>
   - title: Links - example 547
@@ -11235,7 +11237,7 @@ cases:
       [[[foo]]]
 
       [[[foo]]]: /url
-    html: |
+    html: |-
       <p>[[[foo]]]</p>
       <p>[[[foo]]]: /url</p>
   - title: Links - example 548
@@ -11253,7 +11255,7 @@ cases:
       [foo][ref\[]
 
       [ref\[]: /uri
-    html: |
+    html: |-
       <p><a href="/uri">foo</a></p>
   - title: Links - example 549
     mdast:
@@ -11270,7 +11272,7 @@ cases:
       [bar\\]: /uri
 
       [bar\\]
-    html: |
+    html: |-
       <p><a href="/uri">bar\</a></p>
   - title: Links - example 550
     mdast:
@@ -11288,7 +11290,7 @@ cases:
       []
 
       []: /uri
-    html: |
+    html: |-
       <p>[]</p>
       <p>[]: /uri</p>
   - title: Links - example 551
@@ -11313,7 +11315,7 @@ cases:
 
       [
        ]: /uri
-    html: |
+    html: |-
       <p>[
       ]</p>
       <p>[
@@ -11334,7 +11336,7 @@ cases:
       [foo][]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title">foo</a></p>
   - title: Links - example 553
     mdast:
@@ -11356,7 +11358,7 @@ cases:
       [*foo* bar][]
 
       [*foo* bar]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title"><em>foo</em> bar</a></p>
   - title: Links - example 554
     mdast:
@@ -11374,7 +11376,7 @@ cases:
       [Foo][]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title">Foo</a></p>
   - title: Links - example 555
     mdast:
@@ -11397,7 +11399,7 @@ cases:
       []
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title">foo</a>
       []</p>
   - title: Links - example 556
@@ -11416,7 +11418,7 @@ cases:
       [foo]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title">foo</a></p>
   - title: Links - example 557
     mdast:
@@ -11438,7 +11440,7 @@ cases:
       [*foo* bar]
 
       [*foo* bar]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title"><em>foo</em> bar</a></p>
   - title: Links - example 558
     mdast:
@@ -11464,7 +11466,7 @@ cases:
       [[*foo* bar]]
 
       [*foo* bar]: /url "title"
-    html: |
+    html: |-
       <p>[<a href="/url" title="title"><em>foo</em> bar</a>]</p>
   - title: Links - example 559
     mdast:
@@ -11483,7 +11485,7 @@ cases:
       [[bar [foo]
 
       [foo]: /url
-    html: |
+    html: |-
       <p>[[bar <a href="/url">foo</a></p>
   - title: Links - example 560
     mdast:
@@ -11501,7 +11503,7 @@ cases:
       [Foo]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><a href="/url" title="title">Foo</a></p>
   - title: Links - example 561
     mdast:
@@ -11520,7 +11522,7 @@ cases:
       [foo] bar
 
       [foo]: /url
-    html: |
+    html: |-
       <p><a href="/url">foo</a> bar</p>
   - title: Links - example 562
     mdast:
@@ -11534,7 +11536,7 @@ cases:
       \[foo]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p>[foo]</p>
   - title: Links - example 563
     mdast:
@@ -11553,7 +11555,7 @@ cases:
       [foo*]: /url
 
       *[foo*]
-    html: |
+    html: |-
       <p>*<a href="/url">foo*</a></p>
   - title: Links - example 564
     mdast:
@@ -11571,7 +11573,7 @@ cases:
 
       [foo]: /url1
       [bar]: /url2
-    html: |
+    html: |-
       <p><a href="/url2">foo</a></p>
   - title: Links - example 565
     mdast:
@@ -11588,7 +11590,7 @@ cases:
       [foo][]
 
       [foo]: /url1
-    html: |
+    html: |-
       <p><a href="/url1">foo</a></p>
   - title: Links - example 566
     mdast:
@@ -11605,7 +11607,7 @@ cases:
       [foo]()
 
       [foo]: /url1
-    html: |
+    html: |-
       <p><a href="">foo</a></p>
   - title: Links - example 567
     mdast:
@@ -11624,7 +11626,7 @@ cases:
       [foo](not a link)
 
       [foo]: /url1
-    html: |
+    html: |-
       <p><a href="/url1">foo</a>(not a link)</p>
   - title: Links - example 568
     mdast:
@@ -11643,7 +11645,7 @@ cases:
       [foo][bar][baz]
 
       [baz]: /url
-    html: |
+    html: |-
       <p>[foo]<a href="/url">bar</a></p>
   - title: Links - example 569
     mdast:
@@ -11666,7 +11668,7 @@ cases:
 
       [baz]: /url1
       [bar]: /url2
-    html: |
+    html: |-
       <p><a href="/url2">foo</a><a href="/url1">baz</a></p>
   - title: Links - example 570
     mdast:
@@ -11686,94 +11688,108 @@ cases:
 
       [baz]: /url1
       [foo]: /url2
-    html: |
+    html: |-
       <p>[foo]<a href="/url1">bar</a></p>
   - title: Images - example 571
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: foo
-          title: title
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: foo
+              title: title
     myst: |
       ![foo](/url "title")
-    html: |
+    html: |-
       <p><img src="/url" alt="foo" title="title" /></p>
   - title: Images - example 572
     mdast:
       type: root
       children:
-        - type: image
-          url: train.jpg
-          alt: foo bar
-          title: train & tracks
+        - type: paragraph
+          children:
+            - type: image
+              url: train.jpg
+              alt: foo bar
+              title: train & tracks
     myst: |
       ![foo *bar*]
 
       [foo *bar*]: train.jpg "train & tracks"
-    html: |
+    html: |-
       <p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
   - title: Images - example 573
     mdast:
       type: root
       children:
-        - type: image
-          url: /url2
-          alt: foo bar
+        - type: paragraph
+          children:
+            - type: image
+              url: /url2
+              alt: foo bar
     myst: |
       ![foo ![bar](/url)](/url2)
-    html: |
+    html: |-
       <p><img src="/url2" alt="foo bar" /></p>
   - title: Images - example 574
     mdast:
       type: root
       children:
-        - type: image
-          url: /url2
-          alt: foo bar
+        - type: paragraph
+          children:
+            - type: image
+              url: /url2
+              alt: foo bar
     myst: |
       ![foo [bar](/url)](/url2)
-    html: |
+    html: |-
       <p><img src="/url2" alt="foo bar" /></p>
   - title: Images - example 575
     mdast:
       type: root
       children:
-        - type: image
-          url: train.jpg
-          alt: foo bar
-          title: train & tracks
+        - type: paragraph
+          children:
+            - type: image
+              url: train.jpg
+              alt: foo bar
+              title: train & tracks
     myst: |
       ![foo *bar*][]
 
       [foo *bar*]: train.jpg "train & tracks"
-    html: |
+    html: |-
       <p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
   - title: Images - example 576
     mdast:
       type: root
       children:
-        - type: image
-          url: train.jpg
-          alt: foo bar
-          title: train & tracks
+        - type: paragraph
+          children:
+            - type: image
+              url: train.jpg
+              alt: foo bar
+              title: train & tracks
     myst: |
       ![foo *bar*][foobar]
 
       [FOOBAR]: train.jpg "train & tracks"
-    html: |
+    html: |-
       <p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
   - title: Images - example 577
     mdast:
       type: root
       children:
-        - type: image
-          url: train.jpg
-          alt: foo
+        - type: paragraph
+          children:
+            - type: image
+              url: train.jpg
+              alt: foo
     myst: |
       ![foo](train.jpg)
-    html: |
+    html: |-
       <p><img src="train.jpg" alt="foo" /></p>
   - title: Images - example 578
     mdast:
@@ -11789,96 +11805,110 @@ cases:
               title: title
     myst: |
       My ![foo bar](/path/to/train.jpg  "title"   )
-    html: |
+    html: |-
       <p>My <img src="/path/to/train.jpg" alt="foo bar" title="title" /></p>
   - title: Images - example 579
     mdast:
       type: root
       children:
-        - type: image
-          url: url
-          alt: foo
+        - type: paragraph
+          children:
+            - type: image
+              url: url
+              alt: foo
     myst: |
       ![foo](<url>)
-    html: |
+    html: |-
       <p><img src="url" alt="foo" /></p>
   - title: Images - example 580
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
     myst: |
       ![](/url)
-    html: |
+    html: |-
       <p><img src="/url" alt="" /></p>
   - title: Images - example 581
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: foo
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: foo
     myst: |
       ![foo][bar]
 
       [bar]: /url
-    html: |
+    html: |-
       <p><img src="/url" alt="foo" /></p>
   - title: Images - example 582
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: foo
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: foo
     myst: |
       ![foo][bar]
 
       [BAR]: /url
-    html: |
+    html: |-
       <p><img src="/url" alt="foo" /></p>
   - title: Images - example 583
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: foo
-          title: title
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: foo
+              title: title
     myst: |
       ![foo][]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><img src="/url" alt="foo" title="title" /></p>
   - title: Images - example 584
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: foo bar
-          title: title
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: foo bar
+              title: title
     myst: |
       ![*foo* bar][]
 
       [*foo* bar]: /url "title"
-    html: |
+    html: |-
       <p><img src="/url" alt="foo bar" title="title" /></p>
   - title: Images - example 585
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: Foo
-          title: title
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: Foo
+              title: title
     myst: |
       ![Foo][]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><img src="/url" alt="Foo" title="title" /></p>
   - title: Images - example 586
     mdast:
@@ -11899,36 +11929,40 @@ cases:
       []
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><img src="/url" alt="foo" title="title" />
       []</p>
   - title: Images - example 587
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: foo
-          title: title
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: foo
+              title: title
     myst: |
       ![foo]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><img src="/url" alt="foo" title="title" /></p>
   - title: Images - example 588
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: foo bar
-          title: title
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: foo bar
+              title: title
     myst: |
       ![*foo* bar]
 
       [*foo* bar]: /url "title"
-    html: |
+    html: |-
       <p><img src="/url" alt="foo bar" title="title" /></p>
   - title: Images - example 589
     mdast:
@@ -11946,22 +11980,24 @@ cases:
       ![[foo]]
 
       [[foo]]: /url "title"
-    html: |
+    html: |-
       <p>![[foo]]</p>
       <p>[[foo]]: /url &quot;title&quot;</p>
   - title: Images - example 590
     mdast:
       type: root
       children:
-        - type: image
-          url: /url
-          alt: Foo
-          title: title
+        - type: paragraph
+          children:
+            - type: image
+              url: /url
+              alt: Foo
+              title: title
     myst: |
       ![Foo]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p><img src="/url" alt="Foo" title="title" /></p>
   - title: Images - example 591
     mdast:
@@ -11975,7 +12011,7 @@ cases:
       !\[foo]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p>![foo]</p>
   - title: Images - example 592
     mdast:
@@ -11995,7 +12031,7 @@ cases:
       \![foo]
 
       [foo]: /url "title"
-    html: |
+    html: |-
       <p>!<a href="/url" title="title">foo</a></p>
   - title: Autolinks - example 593
     mdast:
@@ -12010,7 +12046,7 @@ cases:
                   value: http://foo.bar.baz
     myst: |
       <http://foo.bar.baz>
-    html: |
+    html: |-
       <p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
   - title: Autolinks - example 594
     mdast:
@@ -12041,7 +12077,7 @@ cases:
                   value: irc://foo.bar:2233/baz
     myst: |
       <irc://foo.bar:2233/baz>
-    html: |
+    html: |-
       <p><a href="irc://foo.bar:2233/baz">irc://foo.bar:2233/baz</a></p>
   - title: Autolinks - example 596
     mdast:
@@ -12056,7 +12092,7 @@ cases:
                   value: MAILTO:FOO@BAR.BAZ
     myst: |
       <MAILTO:FOO@BAR.BAZ>
-    html: |
+    html: |-
       <p><a href="MAILTO:FOO@BAR.BAZ">MAILTO:FOO@BAR.BAZ</a></p>
   - title: Autolinks - example 597
     mdast:
@@ -12071,7 +12107,7 @@ cases:
                   value: a+b+c:d
     myst: |
       <a+b+c:d>
-    html: |
+    html: |-
       <p><a href="a+b+c:d">a+b+c:d</a></p>
   - title: Autolinks - example 598
     mdast:
@@ -12086,7 +12122,7 @@ cases:
                   value: made-up-scheme://foo,bar
     myst: |
       <made-up-scheme://foo,bar>
-    html: |
+    html: |-
       <p><a href="made-up-scheme://foo,bar">made-up-scheme://foo,bar</a></p>
   - title: Autolinks - example 599
     mdast:
@@ -12101,7 +12137,7 @@ cases:
                   value: http://../
     myst: |
       <http://../>
-    html: |
+    html: |-
       <p><a href="http://../">http://../</a></p>
   - title: Autolinks - example 600
     mdast:
@@ -12116,7 +12152,7 @@ cases:
                   value: localhost:5001/foo
     myst: |
       <localhost:5001/foo>
-    html: |
+    html: |-
       <p><a href="localhost:5001/foo">localhost:5001/foo</a></p>
   - title: Autolinks - example 601
     mdast:
@@ -12128,7 +12164,7 @@ cases:
               value: <http://foo.bar/baz bim>
     myst: |
       <http://foo.bar/baz bim>
-    html: |
+    html: |-
       <p>&lt;http://foo.bar/baz bim&gt;</p>
   - title: Autolinks - example 602
     mdast:
@@ -12143,7 +12179,7 @@ cases:
                   value: http://example.com/\[\
     myst: |
       <http://example.com/\[\>
-    html: |
+    html: |-
       <p><a href="http://example.com/%5C%5B%5C">http://example.com/\[\</a></p>
   - title: Autolinks - example 603
     mdast:
@@ -12158,7 +12194,7 @@ cases:
                   value: foo@bar.example.com
     myst: |
       <foo@bar.example.com>
-    html: |
+    html: |-
       <p><a href="mailto:foo@bar.example.com">foo@bar.example.com</a></p>
   - title: Autolinks - example 604
     mdast:
@@ -12186,7 +12222,7 @@ cases:
               value: <foo+@bar.example.com>
     myst: |
       <foo\+@bar.example.com>
-    html: |
+    html: |-
       <p>&lt;foo+@bar.example.com&gt;</p>
   - title: Autolinks - example 606
     mdast:
@@ -12198,7 +12234,7 @@ cases:
               value: <>
     myst: |
       <>
-    html: |
+    html: |-
       <p>&lt;&gt;</p>
   - title: Autolinks - example 607
     mdast:
@@ -12210,7 +12246,7 @@ cases:
               value: < http://foo.bar >
     myst: |
       < http://foo.bar >
-    html: |
+    html: |-
       <p>&lt; http://foo.bar &gt;</p>
   - title: Autolinks - example 608
     mdast:
@@ -12222,7 +12258,7 @@ cases:
               value: <m:abc>
     myst: |
       <m:abc>
-    html: |
+    html: |-
       <p>&lt;m:abc&gt;</p>
   - title: Autolinks - example 609
     mdast:
@@ -12234,7 +12270,7 @@ cases:
               value: <foo.bar.baz>
     myst: |
       <foo.bar.baz>
-    html: |
+    html: |-
       <p>&lt;foo.bar.baz&gt;</p>
   - title: Autolinks - example 610
     mdast:
@@ -12246,7 +12282,7 @@ cases:
               value: http://example.com
     myst: |
       http://example.com
-    html: |
+    html: |-
       <p>http://example.com</p>
   - title: Autolinks - example 611
     mdast:
@@ -12258,7 +12294,7 @@ cases:
               value: foo@bar.example.com
     myst: |
       foo@bar.example.com
-    html: |
+    html: |-
       <p>foo@bar.example.com</p>
   - title: Raw HTML - example 612
     mdast:
@@ -12274,7 +12310,7 @@ cases:
               value: <c2c>
     myst: |
       <a><bab><c2c>
-    html: |
+    html: |-
       <p><a><bab><c2c></p>
   - title: Raw HTML - example 613
     mdast:
@@ -12288,7 +12324,7 @@ cases:
               value: <b2/>
     myst: |
       <a/><b2/>
-    html: |
+    html: |-
       <p><a/><b2/></p>
   - title: Raw HTML - example 614
     mdast:
@@ -12305,7 +12341,7 @@ cases:
     myst: |
       <a  /><b2
       data="foo" >
-    html: |
+    html: |-
       <p><a  /><b2
       data="foo" ></p>
   - title: Raw HTML - example 615
@@ -12321,7 +12357,7 @@ cases:
     myst: |
       <a foo="bar" bam = 'baz <em>"</em>'
       _boolean zoop:33=zoop:33 />
-    html: |
+    html: |-
       <p><a foo="bar" bam = 'baz <em>"</em>'
       _boolean zoop:33=zoop:33 /></p>
   - title: Raw HTML - example 616
@@ -12336,7 +12372,7 @@ cases:
               value: <responsive-image src="foo.jpg" />
     myst: |
       Foo <responsive-image src="foo.jpg" />
-    html: |
+    html: |-
       <p>Foo <responsive-image src="foo.jpg" /></p>
   - title: Raw HTML - example 617
     mdast:
@@ -12348,7 +12384,7 @@ cases:
               value: <33> <__>
     myst: |
       <33> <__>
-    html: |
+    html: |-
       <p>&lt;33&gt; &lt;__&gt;</p>
   - title: Raw HTML - example 618
     mdast:
@@ -12360,7 +12396,7 @@ cases:
               value: <a h*#ref="hi">
     myst: |
       <a h*#ref="hi">
-    html: |
+    html: |-
       <p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>
   - title: Raw HTML - example 619
     mdast:
@@ -12372,7 +12408,7 @@ cases:
               value: <a href="hi'> <a href=hi'>
     myst: |
       <a href="hi'> <a href=hi'>
-    html: |
+    html: |-
       <p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>
   - title: Raw HTML - example 620
     mdast:
@@ -12391,7 +12427,7 @@ cases:
       foo><bar/ >
       <foo bar=baz
       bim!bop />
-    html: |
+    html: |-
       <p>&lt; a&gt;&lt;
       foo&gt;&lt;bar/ &gt;
       &lt;foo bar=baz
@@ -12406,7 +12442,7 @@ cases:
               value: <a href='bar'title=title>
     myst: |
       <a href='bar'title=title>
-    html: |
+    html: |-
       <p>&lt;a href='bar'title=title&gt;</p>
   - title: Raw HTML - example 622
     mdast:
@@ -12420,7 +12456,7 @@ cases:
               value: </foo >
     myst: |
       </a></foo >
-    html: |
+    html: |-
       <p></a></foo ></p>
   - title: Raw HTML - example 623
     mdast:
@@ -12432,7 +12468,7 @@ cases:
               value: </a href="foo">
     myst: |
       </a href="foo">
-    html: |
+    html: |-
       <p>&lt;/a href=&quot;foo&quot;&gt;</p>
   - title: Raw HTML - example 624
     mdast:
@@ -12449,7 +12485,7 @@ cases:
     myst: |
       foo <!-- this is a
       comment - with hyphen -->
-    html: |
+    html: |-
       <p>foo <!-- this is a
       comment - with hyphen --></p>
   - title: Raw HTML - example 625
@@ -12462,7 +12498,7 @@ cases:
               value: foo <!-- not a comment -- two hyphens -->
     myst: |
       foo <!-- not a comment -- two hyphens -->
-    html: |
+    html: |-
       <p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
   - title: Raw HTML - example 626
     mdast:
@@ -12480,7 +12516,7 @@ cases:
       foo <!--> foo -->
 
       foo <!-- foo--->
-    html: |
+    html: |-
       <p>foo &lt;!--&gt; foo --&gt;</p>
       <p>foo &lt;!-- foo---&gt;</p>
   - title: Raw HTML - example 627
@@ -12495,7 +12531,7 @@ cases:
               value: <?php echo $a; ?>
     myst: |
       foo <?php echo $a; ?>
-    html: |
+    html: |-
       <p>foo <?php echo $a; ?></p>
   - title: Raw HTML - example 628
     mdast:
@@ -12509,7 +12545,7 @@ cases:
               value: <!ELEMENT br EMPTY>
     myst: |
       foo <!ELEMENT br EMPTY>
-    html: |
+    html: |-
       <p>foo <!ELEMENT br EMPTY></p>
   - title: Raw HTML - example 629
     mdast:
@@ -12523,7 +12559,7 @@ cases:
               value: <![CDATA[>&<]]>
     myst: |
       foo <![CDATA[>&<]]>
-    html: |
+    html: |-
       <p>foo <![CDATA[>&<]]></p>
   - title: Raw HTML - example 630
     mdast:
@@ -12537,7 +12573,7 @@ cases:
               value: <a href="&ouml;">
     myst: |
       foo <a href="&ouml;">
-    html: |
+    html: |-
       <p>foo <a href="&ouml;"></p>
   - title: Raw HTML - example 631
     mdast:
@@ -12551,7 +12587,7 @@ cases:
               value: <a href="\*">
     myst: |
       foo <a href="\*">
-    html: |
+    html: |-
       <p>foo <a href="\*"></p>
   - title: Raw HTML - example 632
     mdast:
@@ -12563,7 +12599,7 @@ cases:
               value: <a href=""">
     myst: |
       <a href="\"">
-    html: |
+    html: |-
       <p>&lt;a href=&quot;&quot;&quot;&gt;</p>
   - title: Hard line breaks - example 633
     mdast:
@@ -12579,7 +12615,7 @@ cases:
     myst: |
       foo  
       baz
-    html: |
+    html: |-
       <p>foo<br />
       baz</p>
   - title: Hard line breaks - example 634
@@ -12596,7 +12632,7 @@ cases:
     myst: |
       foo\
       baz
-    html: |
+    html: |-
       <p>foo<br />
       baz</p>
   - title: Hard line breaks - example 635
@@ -12613,7 +12649,7 @@ cases:
     myst: |
       foo       
       baz
-    html: |
+    html: |-
       <p>foo<br />
       baz</p>
   - title: Hard line breaks - example 636
@@ -12630,7 +12666,7 @@ cases:
     myst: |
       foo  
            bar
-    html: |
+    html: |-
       <p>foo<br />
       bar</p>
   - title: Hard line breaks - example 637
@@ -12647,7 +12683,7 @@ cases:
     myst: |
       foo\
            bar
-    html: |
+    html: |-
       <p>foo<br />
       bar</p>
   - title: Hard line breaks - example 638
@@ -12666,7 +12702,7 @@ cases:
     myst: |
       *foo  
       bar*
-    html: |
+    html: |-
       <p><em>foo<br />
       bar</em></p>
   - title: Hard line breaks - example 639
@@ -12685,7 +12721,7 @@ cases:
     myst: |
       *foo\
       bar*
-    html: |
+    html: |-
       <p><em>foo<br />
       bar</em></p>
   - title: Hard line breaks - example 640
@@ -12699,7 +12735,7 @@ cases:
     myst: |
       `code  
       span`
-    html: |
+    html: |-
       <p><code>code   span</code></p>
   - title: Hard line breaks - example 641
     mdast:
@@ -12712,7 +12748,7 @@ cases:
     myst: |
       `code\
       span`
-    html: |
+    html: |-
       <p><code>code\ span</code></p>
   - title: Hard line breaks - example 642
     mdast:
@@ -12727,7 +12763,7 @@ cases:
     myst: |
       <a href="foo  
       bar">
-    html: |
+    html: |-
       <p><a href="foo  
       bar"></p>
   - title: Hard line breaks - example 643
@@ -12743,7 +12779,7 @@ cases:
     myst: |
       <a href="foo\
       bar">
-    html: |
+    html: |-
       <p><a href="foo\
       bar"></p>
   - title: Hard line breaks - example 644
@@ -12756,7 +12792,7 @@ cases:
               value: foo\
     myst: |
       foo\
-    html: |
+    html: |-
       <p>foo\</p>
   - title: Hard line breaks - example 645
     mdast:
@@ -12768,7 +12804,7 @@ cases:
               value: foo
     myst: |
       foo
-    html: |
+    html: |-
       <p>foo</p>
   - title: Hard line breaks - example 646
     mdast:
@@ -12781,7 +12817,7 @@ cases:
               value: foo\
     myst: |
       ### foo\
-    html: |
+    html: |-
       <h3>foo\</h3>
   - title: Hard line breaks - example 647
     mdast:
@@ -12794,7 +12830,7 @@ cases:
               value: foo
     myst: |
       ### foo
-    html: |
+    html: |-
       <h3>foo</h3>
   - title: Soft line breaks - example 648
     mdast:
@@ -12809,7 +12845,7 @@ cases:
     myst: |
       foo
       baz
-    html: |
+    html: |-
       <p>foo
       baz</p>
   - title: Soft line breaks - example 649
@@ -12825,7 +12861,7 @@ cases:
     myst: |
       foo 
        baz
-    html: |
+    html: |-
       <p>foo
       baz</p>
   - title: Textual content - example 650
@@ -12838,7 +12874,7 @@ cases:
               value: hello $.;'there
     myst: |
       hello $.;'there
-    html: |
+    html: |-
       <p>hello $.;'there</p>
   - title: Textual content - example 651
     mdast:
@@ -12850,7 +12886,7 @@ cases:
               value: Foo χρῆν
     myst: |
       Foo χρῆν
-    html: |
+    html: |-
       <p>Foo χρῆν</p>
   - title: Textual content - example 652
     mdast:
@@ -12862,5 +12898,5 @@ cases:
               value: Multiple     spaces
     myst: |
       Multiple     spaces
-    html: |
+    html: |-
       <p>Multiple     spaces</p>

--- a/docs/examples/commonmark.links.yml
+++ b/docs/examples/commonmark.links.yml
@@ -1,6 +1,5 @@
 cases:
   - title: CommonMark link reference
-    id: definition
     mdast:
       type: root
       children:
@@ -9,8 +8,6 @@ cases:
           label: 'Key'
           url: 'https://example.com'
           title: example title
-    myst: |-
-      [Key]: https://example.com 'example title'
   - title: CommonMark auto link
     mdast:
       type: root
@@ -53,13 +50,17 @@ cases:
     mdast:
       type: root
       children:
-        - type: image
-          url: src
-          alt: alt
-          title: title
+        - type: paragraph
+          children:
+            - type: image
+              url: src
+              alt: alt
+              title: title
     myst: |-
       ![alt](src "title")
     html: |-
-      <img src="src" alt="alt" title="title">
+      <p>
+        <img src="src" alt="alt" title="title">
+      </p>
     latex: |-
       \includegraphics{src}

--- a/docs/examples/commonmark.lists.yml
+++ b/docs/examples/commonmark.lists.yml
@@ -8,12 +8,12 @@ cases:
           spread: false
           children:
             - type: listItem
-              spread: false
+              spread: true
               children:
                 - type: text
                   value: headings
             - type: listItem
-              spread: false
+              spread: true
               children:
                 - type: text
                   value: lists
@@ -22,17 +22,17 @@ cases:
                   spread: false
                   children:
                     - type: listItem
-                      spread: false
+                      spread: true
                       children:
                         - type: text
                           value: bullets
                     - type: listItem
-                      spread: false
+                      spread: true
                       children:
                         - type: text
                           value: numbers
             - type: listItem
-              spread: false
+              spread: true
               children:
                 - type: text
                   value: code blocks
@@ -74,17 +74,17 @@ cases:
           spread: false
           children:
             - type: listItem
-              spread: false
+              spread: true
               children:
                 - type: text
                   value: quotes
             - type: listItem
-              spread: false
+              spread: true
               children:
                 - type: text
                   value: breaks
             - type: listItem
-              spread: false
+              spread: true
               children:
                 - type: text
                   value: links

--- a/docs/examples/directives.admonitions.yml
+++ b/docs/examples/directives.admonitions.yml
@@ -4,7 +4,7 @@ cases:
       type: root
       children:
         - type: directive
-          kind: attention
+          kind: admonition
           args: This is a title
           value: An example of an admonition with a _title_.
           children:
@@ -90,22 +90,6 @@ cases:
                     - type: text
                       value: |-
                         and an example of a note admonition.
-    myst: |-
-      ```{note} This is a title in myst
-        and an example of a note admonition.
-      ```
-    html: |-
-      <aside class="admonition note">
-        <p class="admonition-title">This is a title in myst</p>
-        <p>
-          and an example of a note admonition.
-        </p>
-      </aside>
-    latex: |-
-      \begin{mdframed}[style=note]
-        \section*{This is a title in myst}
-        and an example of a note admonition.
-      \end{mdframed}
 
   - title: Danger on a single line
     mdast:
@@ -122,17 +106,6 @@ cases:
                   children:
                     - type: text
                       value: This is a title!
-    myst: |-
-      ```{danger} This is a title!
-      ```
-    html: |-
-      <aside class="admonition danger">
-        <p class="admonition-title">This is a title!</p>
-      </aside>
-    latex: |-
-      \begin{mdframed}[style=danger]
-        \section*{This is a title!}
-      \end{mdframed}
 
   - title: Admonition with overridding class name
     mdast:

--- a/docs/examples/directives.figure.yml
+++ b/docs/examples/directives.figure.yml
@@ -42,6 +42,9 @@ cases:
         <figcaption>
           <p>This is the figure caption!</p>
         </figcaption>
+        <div class="legend">
+          <p>Something! A legend!?</p>
+        </div>
       </figure>
 
   - title: Named figure with a caption in a paragraph

--- a/docs/examples/directives.generic.yml
+++ b/docs/examples/directives.generic.yml
@@ -5,10 +5,11 @@ cases:
       children:
         - type: directive
           kind: abc
-          options:
-            a: one
-            b: two
-          value: ABC directive
+          value: |-
+            :a: one
+            :b: two
+
+            ABC directive
     myst: |-
       ```{abc}
       :a: one
@@ -32,10 +33,11 @@ cases:
         - type: directive
           kind: abc
           args: foo bar
-          options:
-            a: one
-            b: two
-          value: ABC directive
+          value: |-
+            :a: one
+            :b: two
+
+            ABC directive
     myst: |-
       ```{abc} foo bar
       :a: one
@@ -45,7 +47,7 @@ cases:
       ```
     html: |-
       <div class="directive unhandled">
-        <p><code class="kind">{abc}</code> <code class="args">foo bar</code></p>
+        <p><code class="kind">{abc}</code><code class="args">foo bar</code></p>
         <pre><code>:a: one
       :b: two
 

--- a/docs/examples/directives.image.yml
+++ b/docs/examples/directives.image.yml
@@ -4,13 +4,17 @@ cases:
     mdast:
       type: root
       children:
-        - type: image
-          url: fun-fish.png
-          alt: fishy
+        - type: paragraph
+          children:
+            - type: image
+              url: fun-fish.png
+              alt: fishy
     myst: |-
       ![fishy](fun-fish.png)
     html: |-
-      <img src="fun-fish.png" alt="fishy">
+      <p>
+        <img src="fun-fish.png" alt="fishy">
+      </p>
 
   - title: Image directive
     mdast:

--- a/docs/examples/references.equations.yml
+++ b/docs/examples/references.equations.yml
@@ -15,20 +15,27 @@ cases:
                   kind: eq
                   identifier: matrix
                   label: '  matrix  '
-        - type: container
+        - type: directive
           kind: figure
-          identifier: matrix
-          label: matrix
-          numbered: true
+          args: fig.jpg
+          options:
+            name: matrix
+          value: Cool caption!
           children:
-            - type: image
-              url: fig.jpg
-            - type: caption
+            - type: container
+              kind: figure
+              identifier: matrix
+              label: matrix
+              numbered: true
               children:
-                - type: paragraph
+                - type: image
+                  url: fig.jpg
+                - type: caption
                   children:
-                    - type: text
-                      value: Cool caption!
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: Cool caption!
     myst: |-
 
       see {eq}`  matrix  `
@@ -62,11 +69,17 @@ cases:
                   kind: eq
                   identifier: matrix
                   label: matrix
-        - type: math
-          identifier: matrix
-          label: matrix
-          value: |-
-            Ax = b
+        - type: directive
+          kind: math
+          options:
+            label: matrix
+          value: Ax = b
+          children:
+            - type: math
+              identifier: matrix
+              label: matrix
+              value: |-
+                Ax = b
     myst: |-
 
       see {eq}`matrix`
@@ -89,11 +102,17 @@ cases:
             - type: link
               url: matrix
               children: []
-        - type: math
-          identifier: matrix
-          label: matrix
-          value: |-
-            Ax = b
+        - type: directive
+          kind: math
+          options:
+            label: matrix
+          value: Ax = b
+          children:
+            - type: math
+              identifier: matrix
+              label: matrix
+              value: |-
+                Ax = b
     myst: |-
 
       see [](matrix)

--- a/docs/examples/references.figures.yml
+++ b/docs/examples/references.figures.yml
@@ -131,20 +131,27 @@ cases:
                   children:
                     - type: text
                       value: Figure %s%s%s, I said {number}
-        - type: container
+        - type: directive
           kind: figure
-          identifier: my-figure
-          label: my-figure
-          numbered: true
+          args: fig.jpg
+          options:
+            name: my-figure
+          value: Cool caption!
           children:
-            - type: image
-              url: fig.jpg
-            - type: caption
+            - type: container
+              kind: figure
+              identifier: my-figure
+              label: my-figure
+              numbered: true
               children:
-                - type: paragraph
+                - type: image
+                  url: fig.jpg
+                - type: caption
                   children:
-                    - type: text
-                      value: Cool caption!
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: Cool caption!
     myst: |-
       see {numref}`Figure %s%s%s, I said {number}<my-figure>`
 
@@ -177,26 +184,33 @@ cases:
                   kind: ref
                   identifier: my-figure
                   label: my-figure
-        - type: container
+        - type: directive
           kind: figure
-          identifier: my-figure
-          label: my-figure
-          numbered: true
+          args: fig.jpg
+          options:
+            name: my-figure
+          value: Cool *caption*!
           children:
-            - type: image
-              url: fig.jpg
-            - type: caption
+            - type: container
+              kind: figure
+              identifier: my-figure
+              label: my-figure
+              numbered: true
               children:
-                - type: paragraph
+                - type: image
+                  url: fig.jpg
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Cool '
-                    - type: emphasis
+                    - type: paragraph
                       children:
                         - type: text
-                          value: caption
-                    - type: text
-                      value: '!'
+                          value: 'Cool '
+                        - type: emphasis
+                          children:
+                            - type: text
+                              value: caption
+                        - type: text
+                          value: '!'
     myst: |-
       see {ref}`my-figure`
 
@@ -232,26 +246,33 @@ cases:
                   children:
                     - type: text
                       value: Custom *caption*
-        - type: container
+        - type: directive
           kind: figure
-          identifier: my-figure
-          label: my-figure
-          numbered: true
+          args: fig.jpg
+          options:
+            name: my-figure
+          value: Cool *caption*!
           children:
-            - type: image
-              url: fig.jpg
-            - type: caption
+            - type: container
+              kind: figure
+              identifier: my-figure
+              label: my-figure
+              numbered: true
               children:
-                - type: paragraph
+                - type: image
+                  url: fig.jpg
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Cool '
-                    - type: emphasis
+                    - type: paragraph
                       children:
                         - type: text
-                          value: caption
-                    - type: text
-                      value: '!'
+                          value: 'Cool '
+                        - type: emphasis
+                          children:
+                            - type: text
+                              value: caption
+                        - type: text
+                          value: '!'
     myst: |-
       see {ref}`Custom *caption* <my-figure>`
 
@@ -280,26 +301,33 @@ cases:
               url: my-figure
               title: Figure title
               children: []
-        - type: container
+        - type: directive
           kind: figure
-          identifier: my-figure
-          label: my-figure
-          numbered: true
+          args: fig.jpg
+          options:
+            name: my-figure
+          value: Cool *caption*!
           children:
-            - type: image
-              url: fig.jpg
-            - type: caption
+            - type: container
+              kind: figure
+              identifier: my-figure
+              label: my-figure
+              numbered: true
               children:
-                - type: paragraph
+                - type: image
+                  url: fig.jpg
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Cool '
-                    - type: emphasis
+                    - type: paragraph
                       children:
                         - type: text
-                          value: caption
-                    - type: text
-                      value: '!'
+                          value: 'Cool '
+                        - type: emphasis
+                          children:
+                            - type: text
+                              value: caption
+                        - type: text
+                          value: '!'
     myst: |-
       see [](my-figure "Figure title")
 
@@ -333,26 +361,33 @@ cases:
                   children:
                     - type: text
                       value: caption
-        - type: container
+        - type: directive
           kind: figure
-          identifier: my-figure
-          label: my-figure
-          numbered: true
+          args: fig.jpg
+          options:
+            name: my-figure
+          value: Cool *caption*!
           children:
-            - type: image
-              url: fig.jpg
-            - type: caption
+            - type: container
+              kind: figure
+              identifier: my-figure
+              label: my-figure
+              numbered: true
               children:
-                - type: paragraph
+                - type: image
+                  url: fig.jpg
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Cool '
-                    - type: emphasis
+                    - type: paragraph
                       children:
                         - type: text
-                          value: caption
-                    - type: text
-                      value: '!'
+                          value: 'Cool '
+                        - type: emphasis
+                          children:
+                            - type: text
+                              value: caption
+                        - type: text
+                          value: '!'
     myst: |-
       see [Custom *caption*](my-figure)
 

--- a/docs/examples/references.tables.yml
+++ b/docs/examples/references.tables.yml
@@ -16,32 +16,41 @@ cases:
                   kind: numref
                   identifier: my-table
                   label: my-table
-        - type: container
-          kind: table
-          identifier: my-table
-          label: my-table
-          numbered: true
+        - type: directive
+          kind: list-table
+          args: Caption text
+          options:
+            name: my-table
+          value: |-
+            *   - Head 1
+            *   - Row 1
           children:
-            - type: caption
+            - type: container
+              kind: table
+              identifier: my-table
+              label: my-table
+              numbered: true
               children:
-                - type: paragraph
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Caption text'
-            - type: table
-              children:
-                - type: tableRow
-                  children:
-                    - type: tableCell
+                    - type: paragraph
                       children:
                         - type: text
-                          value: Head 1
-                - type: tableRow
+                          value: 'Caption text'
+                - type: table
                   children:
-                    - type: tableCell
+                    - type: tableRow
                       children:
-                        - type: text
-                          value: Row 1
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Head 1
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1
     myst: |-
       see {numref}`my-table`
 
@@ -89,32 +98,41 @@ cases:
                   children:
                     - type: text
                       value: T%s
-        - type: container
-          kind: table
-          identifier: my-table
-          label: my-table
-          numbered: true
+        - type: directive
+          kind: list-table
+          args: Caption text
+          options:
+            name: my-table
+          value: |-
+            *   - Head 1
+            *   - Row 1
           children:
-            - type: caption
+            - type: container
+              kind: table
+              identifier: my-table
+              label: my-table
+              numbered: true
               children:
-                - type: paragraph
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Caption text'
-            - type: table
-              children:
-                - type: tableRow
-                  children:
-                    - type: tableCell
+                    - type: paragraph
                       children:
                         - type: text
-                          value: Head 1
-                - type: tableRow
+                          value: 'Caption text'
+                - type: table
                   children:
-                    - type: tableCell
+                    - type: tableRow
                       children:
-                        - type: text
-                          value: Row 1
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Head 1
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1
     myst: |-
       see {numref}`T%s <my-table>`
 
@@ -158,32 +176,41 @@ cases:
                   kind: ref
                   identifier: my-table
                   label: my-table
-        - type: container
-          kind: table
-          identifier: my-table
-          label: my-table
-          numbered: true
+        - type: directive
+          kind: list-table
+          args: Caption text
+          options:
+            name: my-table
+          value: |-
+            *   - Head 1
+            *   - Row 1
           children:
-            - type: caption
+            - type: container
+              kind: table
+              identifier: my-table
+              label: my-table
+              numbered: true
               children:
-                - type: paragraph
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Caption text'
-            - type: table
-              children:
-                - type: tableRow
-                  children:
-                    - type: tableCell
+                    - type: paragraph
                       children:
                         - type: text
-                          value: Head 1
-                - type: tableRow
+                          value: 'Caption text'
+                - type: table
                   children:
-                    - type: tableCell
+                    - type: tableRow
                       children:
-                        - type: text
-                          value: Row 1
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Head 1
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1
     myst: |-
       see {ref}`my-table`
 
@@ -230,32 +257,41 @@ cases:
                   children:
                     - type: text
                       value: My Table
-        - type: container
-          kind: table
-          identifier: my-table
-          label: my-table
-          numbered: true
+        - type: directive
+          kind: list-table
+          args: Caption text
+          options:
+            name: my-table
+          value: |-
+            *   - Head 1
+            *   - Row 1
           children:
-            - type: caption
+            - type: container
+              kind: table
+              identifier: my-table
+              label: my-table
+              numbered: true
               children:
-                - type: paragraph
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Caption text'
-            - type: table
-              children:
-                - type: tableRow
-                  children:
-                    - type: tableCell
+                    - type: paragraph
                       children:
                         - type: text
-                          value: Head 1
-                - type: tableRow
+                          value: 'Caption text'
+                - type: table
                   children:
-                    - type: tableCell
+                    - type: tableRow
                       children:
-                        - type: text
-                          value: Row 1
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Head 1
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1
     myst: |-
       see {ref}`My Table <my-table>`
 
@@ -294,32 +330,41 @@ cases:
             - type: link
               url: my-table
               children: []
-        - type: container
-          kind: table
-          identifier: my-table
-          label: my-table
-          numbered: true
+        - type: directive
+          kind: list-table
+          args: Caption text
+          options:
+            name: my-table
+          value: |-
+            *   - Head 1
+            *   - Row 1
           children:
-            - type: caption
+            - type: container
+              kind: table
+              identifier: my-table
+              label: my-table
+              numbered: true
               children:
-                - type: paragraph
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Caption text'
-            - type: table
-              children:
-                - type: tableRow
-                  children:
-                    - type: tableCell
+                    - type: paragraph
                       children:
                         - type: text
-                          value: Head 1
-                - type: tableRow
+                          value: 'Caption text'
+                - type: table
                   children:
-                    - type: tableCell
+                    - type: tableRow
                       children:
-                        - type: text
-                          value: Row 1
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Head 1
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1
     myst: |-
       see [](my-table)
 
@@ -365,32 +410,41 @@ cases:
                   children:
                     - type: text
                       value: Table
-        - type: container
-          kind: table
-          identifier: my-table
-          label: my-table
-          numbered: true
+        - type: directive
+          kind: list-table
+          args: Caption text
+          options:
+            name: my-table
+          value: |-
+            *   - Head 1
+            *   - Row 1
           children:
-            - type: caption
+            - type: container
+              kind: table
+              identifier: my-table
+              label: my-table
+              numbered: true
               children:
-                - type: paragraph
+                - type: caption
                   children:
-                    - type: text
-                      value: 'Caption text'
-            - type: table
-              children:
-                - type: tableRow
-                  children:
-                    - type: tableCell
+                    - type: paragraph
                       children:
                         - type: text
-                          value: Head 1
-                - type: tableRow
+                          value: 'Caption text'
+                - type: table
                   children:
-                    - type: tableCell
+                    - type: tableRow
                       children:
-                        - type: text
-                          value: Row 1
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Head 1
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1
     myst: |-
       see [My *Table*](my-table "different title")
 

--- a/docs/examples/roles.generic.yml
+++ b/docs/examples/roles.generic.yml
@@ -21,10 +21,6 @@ cases:
           children:
             - type: role
               kind: abc
-    myst: |-
-      {abc}``
-    html: |-
-      <p><span class="role unhandled"><code class="kind">{abc}</code></span></p>
   - title: unknown role - invalid no kind
     invalid: true
     mdast:

--- a/docs/features/commonmark.md
+++ b/docs/features/commonmark.md
@@ -78,10 +78,6 @@ which is used to structurally seperate content.
 
 ```
 
-```{include} ../examples/definition.md
-
-```
-
 ```{seealso}
 These can be used in [](inline-links) and are similar to [](./references.md) in MyST.
 This syntax is also similar to [](./footnotes.md).

--- a/schema/commonmark.schema.json
+++ b/schema/commonmark.schema.json
@@ -525,8 +525,7 @@
       "required": ["url"],
       "properties": {
         "url": {
-          "type": "string",
-          "format": "uri-reference"
+          "type": "string"
         },
         "title": {
           "description": "advisory information, e.g. for a tooltip",


### PR DESCRIPTION
This PR is motivated by testing myst-spec examples in mystjs. It includes a few changes:
- adding nested role / directive nodes to examples
- removing some myst / html conversions from the test where those conversions are unsupported (or don't make sense)
- nested some standalone images in paragraphs (for better or worse...)
- fixed some typos, particularly in commonmark mdast