### PR TITLE
♻️ REFACTOR: `role -> mystRole` and `directive -> mystDirective`

### DIFF
--- a/docs/examples/directives.admonitions.simple.yml
+++ b/docs/examples/directives.admonitions.simple.yml
@@ -3,7 +3,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: attention
           args: Admonition attention
           children:
@@ -31,7 +31,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: caution
           args: Admonition caution
           children:
@@ -59,7 +59,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: danger
           args: Admonition danger
           children:
@@ -87,7 +87,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: error
           args: Admonition error
           children:
@@ -115,7 +115,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: important
           args: Admonition important
           children:
@@ -143,7 +143,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: hint
           args: Admonition hint
           children:
@@ -171,7 +171,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: note
           args: Admonition note
           children:
@@ -199,7 +199,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: seealso
           args: Admonition seealso
           children:
@@ -227,7 +227,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: tip
           args: Admonition tip
           children:
@@ -255,7 +255,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: warning
           args: Admonition warning
           children:

--- a/docs/examples/directives.admonitions.yml
+++ b/docs/examples/directives.admonitions.yml
@@ -3,7 +3,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: admonition
           args: This is a title
           value: An example of an admonition with a _title_.
@@ -43,7 +43,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: note
           value: Please note!
           children:
@@ -73,7 +73,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: note
           args: This is a title in myst
           value: and an example of a note admonition.
@@ -95,7 +95,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: danger
           args: This is a title!
           children:
@@ -111,7 +111,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: admonition
           args: This is a title!
           options:
@@ -161,7 +161,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: seealso
           options:
             class: tip

--- a/docs/examples/directives.code.yml
+++ b/docs/examples/directives.code.yml
@@ -3,7 +3,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: code
           args: python
           options:
@@ -33,7 +33,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: code
           args: python
           options:
@@ -71,7 +71,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: code-block
           args: python
           options:
@@ -111,7 +111,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: code-block
           args: python
           options:
@@ -151,7 +151,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: code-block
           args: python
           options:

--- a/docs/examples/directives.figure.yml
+++ b/docs/examples/directives.figure.yml
@@ -4,7 +4,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: https://via.placeholder.com/150
           value: |-
@@ -51,7 +51,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: https://via.placeholder.com/150
           options:
@@ -100,7 +100,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: https://via.placeholder.com/150
           options:
@@ -139,7 +139,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: https://via.placeholder.com/150
           options:
@@ -177,7 +177,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: https://via.placeholder.com/150
           options:
@@ -198,7 +198,7 @@ cases:
                       children:
                         - type: text
                           value: This is the figure caption!
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: https://via.placeholder.com/151
           options:

--- a/docs/examples/directives.generic.yml
+++ b/docs/examples/directives.generic.yml
@@ -3,7 +3,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: abc
           value: |-
             :a: one
@@ -30,7 +30,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: abc
           args: foo bar
           value: |-

--- a/docs/examples/directives.image.yml
+++ b/docs/examples/directives.image.yml
@@ -20,7 +20,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: image
           args: fun-fish.png
           options:
@@ -51,7 +51,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: image
           args: fun-fish.png
           options:

--- a/docs/examples/directives.math.yml
+++ b/docs/examples/directives.math.yml
@@ -3,7 +3,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: math
           value: Ax = b
           children:
@@ -26,7 +26,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: math
           options:
             label: matrix

--- a/docs/examples/directives.table.yml
+++ b/docs/examples/directives.table.yml
@@ -65,7 +65,7 @@ cases:
     mdast:
       type: root
       children:
-        - type: directive
+        - type: mystDirective
           kind: list-table
           args: Caption *text*
           options:

--- a/docs/examples/references.equations.yml
+++ b/docs/examples/references.equations.yml
@@ -7,7 +7,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: eq
               value: '  matrix  '
               children:
@@ -15,7 +15,7 @@ cases:
                   kind: eq
                   identifier: matrix
                   label: '  matrix  '
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: fig.jpg
           options:
@@ -61,7 +61,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: eq
               value: matrix
               children:
@@ -69,7 +69,7 @@ cases:
                   kind: eq
                   identifier: matrix
                   label: matrix
-        - type: directive
+        - type: mystDirective
           kind: math
           options:
             label: matrix
@@ -102,7 +102,7 @@ cases:
             - type: link
               url: matrix
               children: []
-        - type: directive
+        - type: mystDirective
           kind: math
           options:
             label: matrix

--- a/docs/examples/references.figures.yml
+++ b/docs/examples/references.figures.yml
@@ -5,7 +5,7 @@ cases:
       children:
         - type: paragraph
           children:
-            - type: role
+            - type: mystRole
               kind: numref
               value: my-figure
               children:
@@ -23,7 +23,7 @@ cases:
       children:
         - type: paragraph
           children:
-            - type: role
+            - type: mystRole
               kind: numref
               value: Figure %s <my-figure>
               children:
@@ -44,7 +44,7 @@ cases:
       children:
         - type: paragraph
           children:
-            - type: role
+            - type: mystRole
               kind: numref
               value: Figure %s <  My   -   Figure  >
               children:
@@ -67,7 +67,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: numref
               value: my-figure
               children:
@@ -75,7 +75,7 @@ cases:
                   kind: numref
                   identifier: my-figure
                   label: my-figure
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: fig.jpg
           options:
@@ -120,7 +120,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: numref
               value: Figure %s%s%s, I said {number}<my-figure>
               children:
@@ -131,7 +131,7 @@ cases:
                   children:
                     - type: text
                       value: Figure %s%s%s, I said {number}
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: fig.jpg
           options:
@@ -176,7 +176,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: ref
               value: my-figure
               children:
@@ -184,7 +184,7 @@ cases:
                   kind: ref
                   identifier: my-figure
                   label: my-figure
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: fig.jpg
           options:
@@ -235,7 +235,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: ref
               value: Custom *caption* <my-figure>
               children:
@@ -246,7 +246,7 @@ cases:
                   children:
                     - type: text
                       value: Custom *caption*
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: fig.jpg
           options:
@@ -301,7 +301,7 @@ cases:
               url: my-figure
               title: Figure title
               children: []
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: fig.jpg
           options:
@@ -361,7 +361,7 @@ cases:
                   children:
                     - type: text
                       value: caption
-        - type: directive
+        - type: mystDirective
           kind: figure
           args: fig.jpg
           options:

--- a/docs/examples/references.headings.yml
+++ b/docs/examples/references.headings.yml
@@ -7,7 +7,7 @@ cases:
           children:
             - type: text
               value: 'See: '
-            - type: role
+            - type: mystRole
               kind: ref
               value: my_id
               children:
@@ -43,7 +43,7 @@ cases:
           children:
             - type: text
               value: 'See: '
-            - type: role
+            - type: mystRole
               kind: ref
               value: something... <my_id>
               children:

--- a/docs/examples/references.tables.yml
+++ b/docs/examples/references.tables.yml
@@ -8,7 +8,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: numref
               value: my-table
               children:
@@ -16,7 +16,7 @@ cases:
                   kind: numref
                   identifier: my-table
                   label: my-table
-        - type: directive
+        - type: mystDirective
           kind: list-table
           args: Caption text
           options:
@@ -87,7 +87,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: numref
               value: T%s <my-table>
               children:
@@ -98,7 +98,7 @@ cases:
                   children:
                     - type: text
                       value: T%s
-        - type: directive
+        - type: mystDirective
           kind: list-table
           args: Caption text
           options:
@@ -168,7 +168,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: ref
               value: my-table
               children:
@@ -176,7 +176,7 @@ cases:
                   kind: ref
                   identifier: my-table
                   label: my-table
-        - type: directive
+        - type: mystDirective
           kind: list-table
           args: Caption text
           options:
@@ -246,7 +246,7 @@ cases:
           children:
             - type: text
               value: 'see '
-            - type: role
+            - type: mystRole
               kind: ref
               value: My Table <my-table>
               children:
@@ -257,7 +257,7 @@ cases:
                   children:
                     - type: text
                       value: My Table
-        - type: directive
+        - type: mystDirective
           kind: list-table
           args: Caption text
           options:
@@ -330,7 +330,7 @@ cases:
             - type: link
               url: my-table
               children: []
-        - type: directive
+        - type: mystDirective
           kind: list-table
           args: Caption text
           options:
@@ -410,7 +410,7 @@ cases:
                   children:
                     - type: text
                       value: Table
-        - type: directive
+        - type: mystDirective
           kind: list-table
           args: Caption text
           options:

--- a/docs/examples/roles.generic.yml
+++ b/docs/examples/roles.generic.yml
@@ -6,7 +6,7 @@ cases:
       children:
         - type: paragraph
           children:
-            - type: role
+            - type: mystRole
               kind: abc
               value: ABC role
     myst: |-
@@ -19,7 +19,7 @@ cases:
       children:
         - type: paragraph
           children:
-            - type: role
+            - type: mystRole
               kind: abc
   - title: unknown role - invalid no kind
     invalid: true
@@ -28,5 +28,5 @@ cases:
       children:
         - type: paragraph
           children:
-            - type: role
+            - type: mystRole
               value: ABC role

--- a/docs/examples/roles.html.abbr.yml
+++ b/docs/examples/roles.html.abbr.yml
@@ -8,7 +8,7 @@ cases:
           children:
             - type: text
               value: 'Well '
-            - type: role
+            - type: mystRole
               kind: abbr
               value: CSS (Cascading Style Sheets)
               children:
@@ -32,7 +32,7 @@ cases:
           children:
             - type: text
               value: 'Well '
-            - type: role
+            - type: mystRole
               kind: abbr
               value: CSS
               children:
@@ -53,7 +53,7 @@ cases:
       children:
         - type: paragraph
           children:
-            - type: role
+            - type: mystRole
               kind: abbr
               value: CSS (Cascading) Style( Sheets)
               children:

--- a/docs/examples/roles.html.yml
+++ b/docs/examples/roles.html.yml
@@ -7,7 +7,7 @@ cases:
           children:
             - type: text
               value: H
-            - type: role
+            - type: mystRole
               kind: sub
               value: '2'
               children:
@@ -33,7 +33,7 @@ cases:
           children:
             - type: text
               value: H
-            - type: role
+            - type: mystRole
               kind: subscript
               value: '2'
               children:
@@ -58,7 +58,7 @@ cases:
           children:
             - type: text
               value: '4'
-            - type: role
+            - type: mystRole
               kind: sup
               value: th
               children:
@@ -82,7 +82,7 @@ cases:
           children:
             - type: text
               value: '4'
-            - type: role
+            - type: mystRole
               kind: superscript
               value: th
               children:

--- a/docs/examples/roles.math.yml
+++ b/docs/examples/roles.math.yml
@@ -8,7 +8,7 @@ cases:
           children:
             - type: text
               value: 'This is genius '
-            - type: role
+            - type: mystRole
               kind: math
               value: e=mc^2
               children:

--- a/schema/directives.schema.json
+++ b/schema/directives.schema.json
@@ -11,7 +11,7 @@
           "required": ["kind"],
           "properties": {
             "type": {
-              "const": "directive"
+              "const": "mystDirective"
             },
             "kind": {
               "type": "string"

--- a/schema/roles.schema.json
+++ b/schema/roles.schema.json
@@ -11,7 +11,7 @@
           "required": ["kind"],
           "properties": {
             "type": {
-              "const": "role"
+              "const": "mystRole"
             },
             "kind": {
               "type": "string"


### PR DESCRIPTION
Changing these types intends to reduce naming conflicts.
For instance with: https://github.com/syntax-tree/mdast-util-directive

closes #26 