### PR TITLE
MAINT: Add CNAME to gh pages action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html
+          cname: spec.myst.tools


### PR DESCRIPTION
I believe that this sets up the proper CNAME to point to spec.myst.tools - I also gave @rowanc1 manager access to the DNS entries for myst.tools to set up the necessary config on NameCheap 