### PR TITLE
ENH: add `blockquote` to supported container contents

### DIFF
--- a/schema/containers.schema.json
+++ b/schema/containers.schema.json
@@ -16,7 +16,7 @@
             "kind": {
               "description": "kind of container contents",
               "type": "string",
-              "enum": ["figure", "table", "blockquote"]
+              "enum": ["figure", "table", "quote"]
             },
             "class": {
               "description": "any custom class information",

--- a/schema/containers.schema.json
+++ b/schema/containers.schema.json
@@ -16,7 +16,7 @@
             "kind": {
               "description": "kind of container contents",
               "type": "string",
-              "enum": ["figure", "table"]
+              "enum": ["figure", "table", "blockquote"]
             },
             "class": {
               "description": "any custom class information",


### PR DESCRIPTION
Containers are already used to add captions to blockquotes, so this PR can merge independently of any work on epigraphs.